### PR TITLE
cost_w_io

### DIFF
--- a/udao_spark/optimizer/base_optimizer.py
+++ b/udao_spark/optimizer/base_optimizer.py
@@ -16,8 +16,6 @@ from ..model.model_server import ModelServer
 from ..utils.constants import THETA_C, THETA_P, THETA_S
 
 ThetaType = Literal["c", "p", "s"]
-aws_cost_cpu_hour_ratio = 0.052624
-aws_cost_mem_hour_ratio = 0.0057785  # for GB*H
 
 
 class BaseOptimizer(ABC):
@@ -102,14 +100,6 @@ class BaseOptimizer(ABC):
             :, : -len(self.decision_variables)
         ]
         return graph_embedding, non_decision_tabular_features
-
-    def get_cloud_cost(
-        self, lat: th.Tensor, cores: th.Tensor, mem: th.Tensor, nexec: th.Tensor
-    ) -> th.Tensor:
-        cpu_hour = (nexec + 1) * cores * lat / 3600
-        mem_hour = (nexec + 1) * mem * lat / 3600
-        cost = cpu_hour * aws_cost_cpu_hour_ratio + mem_hour * aws_cost_mem_hour_ratio
-        return cost
 
     def _predict_objectives(
         self, graph_embedding: th.Tensor, tabular_features: th.Tensor

--- a/udao_spark/optimizer/utils.py
+++ b/udao_spark/optimizer/utils.py
@@ -1,0 +1,37 @@
+from typing import Union
+
+import numpy as np
+import pandas as pd
+import torch as th
+
+UdaoNumeric = Union[float, pd.Series, np.ndarray, th.Tensor]
+
+aws_cost_cpu_hour_ratio = 0.052624
+aws_cost_mem_hour_ratio = 0.0057785  # for GB*H
+io_gb_ratio = 0.02  # for GB
+
+
+def get_cloud_cost_wo_io(
+    lat: UdaoNumeric, cores: UdaoNumeric, mem: UdaoNumeric, nexec: UdaoNumeric
+) -> UdaoNumeric:
+    cpu_hour = (nexec + 1) * cores * lat / 3600.0
+    mem_hour = (nexec + 1) * mem * lat / 3600.0
+    cost = cpu_hour * aws_cost_cpu_hour_ratio + mem_hour * aws_cost_mem_hour_ratio
+    return cost
+
+
+def get_cloud_cost_add_io(
+    cost_wo_io: UdaoNumeric,
+    io_mb: UdaoNumeric,
+) -> UdaoNumeric:
+    return cost_wo_io + io_mb / 1024.0 * io_gb_ratio
+
+
+def get_cloud_cost_w_io(
+    lat: UdaoNumeric,
+    cores: UdaoNumeric,
+    mem: UdaoNumeric,
+    nexec: UdaoNumeric,
+    io_mb: UdaoNumeric,
+) -> UdaoNumeric:
+    return get_cloud_cost_add_io(get_cloud_cost_wo_io(lat, cores, mem, nexec), io_mb)


### PR DESCRIPTION
add io as part of the cost function. set `io_gb_ratio = 0.02 $/GB` to dominate the cost contributed by cpu-hour and memory-hour.

<img width="565" alt="image" src="https://github.com/Angryrou/udao-spark-optimizer/assets/8079921/98734b05-92a2-44cf-9bdd-0446a7d8e5b4">
