### PR TITLE
grid-search-more-sample-rate

### DIFF
--- a/udao_spark/optimizer/hierarchical_optimizer.py
+++ b/udao_spark/optimizer/hierarchical_optimizer.py
@@ -177,7 +177,7 @@ class HierarchicalOptimizer(BaseOptimizer):
             join_ids = []
             for qs_id, v in non_decision_input.items():
                 if ".Join" in JsonHandler.dump_to_string(v["qs_lqp"]):
-                    join_ids.append(qs_id)
+                    join_ids.append(int(qs_id.split("-")[1]))
             print(f"template: {template}: join_ids is {join_ids}")
             objs, conf = self._hmooc(
                 len_theta_per_subQ,
@@ -322,7 +322,7 @@ class HierarchicalOptimizer(BaseOptimizer):
         is_oracle: bool,
         save_data_header: str,
         benchmark: str,
-        join_ids: List[str],
+        join_ids: List[int],
         weights: np.ndarray = np.array([1.0, 1.0]),
     ) -> Tuple[Optional[np.ndarray], Optional[np.ndarray]]:
         start = time.time()
@@ -455,7 +455,7 @@ class HierarchicalOptimizer(BaseOptimizer):
             if len(join_ids) > 0:
                 theta[s3] = "{}MB".format(
                     min(
-                        int(fine_conf["runtime_theta"][ji]["theta_p"][s3][:-2])
+                        int(fine_conf["runtime_theta"][f"qs{ji}"]["theta_p"][s3][:-2])
                         for ji in join_ids
                     )
                 )
@@ -463,14 +463,18 @@ class HierarchicalOptimizer(BaseOptimizer):
                     max(
                         10,
                         min(
-                            int(fine_conf["runtime_theta"][ji]["theta_p"][s4][:-2])
+                            int(
+                                fine_conf["runtime_theta"][f"qs{ji}"]["theta_p"][s4][
+                                    :-2
+                                ]
+                            )
                             for ji in join_ids
                         ),
                     )
                 )
                 theta[s5] = str(
                     max(
-                        int(fine_conf["runtime_theta"][ji]["theta_p"][s5])
+                        int(fine_conf["runtime_theta"][f"qs{ji}"]["theta_p"][s5])
                         for ji in join_ids
                     )
                 )

--- a/udao_spark/optimizer/hierarchical_optimizer.py
+++ b/udao_spark/optimizer/hierarchical_optimizer.py
@@ -30,7 +30,7 @@ from udao_spark.optimizer.utils import (
     even_weights,
     save_json,
     save_results,
-    weighted_utopia_nearest_impl,
+    weighted_utopia_nearest,
 )
 from udao_spark.utils.logging import logger
 from udao_spark.utils.monitor import DivAndConqMonitor, UdaoMonitor
@@ -312,6 +312,7 @@ class HierarchicalOptimizer(BaseOptimizer):
         is_oracle: bool,
         save_data_header: str,
         benchmark: str,
+        weights: np.ndarray = np.array([1.0, 1.0]),
     ) -> Tuple[Optional[np.ndarray], Optional[np.ndarray]]:
         start = time.time()
         theta_c: Union[th.Tensor, np.ndarray]
@@ -426,7 +427,7 @@ class HierarchicalOptimizer(BaseOptimizer):
                 )
 
         # add WUN
-        objs, conf = weighted_utopia_nearest_impl(po_objs, conf_raw)
+        objs, conf = weighted_utopia_nearest(po_objs, conf_raw, weights)
         tc_po_rec = time.time() - start_rec
         print(f"FUNCTION: time cost of {algo} with WUN " f"is: {tc_po_rec}")
 
@@ -466,6 +467,7 @@ class HierarchicalOptimizer(BaseOptimizer):
         save_data_header: str,
         is_query_control: bool,
         is_oracle: bool,
+        weights: np.ndarray = np.array([1.0, 1.0]),
     ) -> Tuple[Optional[np.ndarray], Optional[np.ndarray]]:
         start = time.time()
         if use_ag:
@@ -580,7 +582,7 @@ class HierarchicalOptimizer(BaseOptimizer):
             )
 
         # add WUN
-        objs, conf = weighted_utopia_nearest_impl(po_objs, conf2)
+        objs, conf = weighted_utopia_nearest(po_objs, conf2, weights)
         tc_po_rec = time.time() - start_rec
         print(f"FUNCTION: time cost of {algo} with WUN " f"is: {tc_po_rec}")
 
@@ -620,6 +622,7 @@ class HierarchicalOptimizer(BaseOptimizer):
         save_data_header: str,
         is_query_control: bool,
         is_oracle: bool,
+        weights: np.ndarray = np.array([1.0, 1.0]),
     ) -> Tuple[Optional[np.ndarray], Optional[np.ndarray]]:
         start = time.time()
         if use_ag:
@@ -747,7 +750,7 @@ class HierarchicalOptimizer(BaseOptimizer):
             )
 
         # add WUN
-        objs, conf = weighted_utopia_nearest_impl(po_objs, conf2)
+        objs, conf = weighted_utopia_nearest(po_objs, conf2, weights)
         tc_po_rec = time.time() - start_rec
         print(f"FUNCTION: time cost of {algo} with WUN " f"is: {tc_po_rec}")
 
@@ -787,6 +790,7 @@ class HierarchicalOptimizer(BaseOptimizer):
         is_query_control: bool,
         save_data_header: str,
         is_oracle: bool,
+        weights: np.ndarray = np.array([1.0, 1.0]),
     ) -> Tuple[Optional[np.ndarray], Optional[np.ndarray]]:
         start = time.time()
         if use_ag:
@@ -970,7 +974,7 @@ class HierarchicalOptimizer(BaseOptimizer):
             )
 
         # add WUN
-        objs, conf = weighted_utopia_nearest_impl(po_objs, conf2)
+        objs, conf = weighted_utopia_nearest(po_objs, conf2, weights)
         tc_po_rec = time.time() - start_rec
         print(f"FUNCTION: time cost of {algo} with WUN " f"is: {tc_po_rec}")
 

--- a/udao_spark/optimizer/hierarchical_optimizer.py
+++ b/udao_spark/optimizer/hierarchical_optimizer.py
@@ -425,9 +425,6 @@ class HierarchicalOptimizer(BaseOptimizer):
                 )
             }
             fine_conf["runtime_theta"] = {}
-            theta = {
-                k: v for k, v in zip(self.sc.knob_names, fine_conf_qs_raw[i * n_subQs])
-            }
             for j in range(n_subQs):
                 qs_theta_p = {
                     k: v
@@ -447,25 +444,41 @@ class HierarchicalOptimizer(BaseOptimizer):
                         ],
                     )
                 }
-                if f"qs-{j}" in join_ids:
-                    theta[s3] = "{}MB".format(
-                        min(int(theta[s3][:-2]), int(qs_theta_p[s3][:-2]))
-                    )
-                    theta[s4] = "{}MB".format(
-                        max(
-                            10,
-                            min(
-                                int(theta[s4][:-2]),
-                                int(qs_theta_p[s4][:-2]),
-                            ),
-                        )
-                    )
-                    theta[s5] = str(max(int(theta[s5]), int(qs_theta_p[s5])))
 
                 fine_conf["runtime_theta"][f"qs{j}"] = {
                     "theta_p": qs_theta_p,
                     "theta_s": qs_theta_s,
                 }
+            theta = {
+                k: v for k, v in zip(self.sc.knob_names, fine_conf_qs_raw[i * n_subQs])
+            }
+            if len(join_ids) > 0:
+                theta[s3] = "{}MB".format(
+                    min(
+                        int(fine_conf["runtime_theta"][f"qs{ji}"]["theta_p"][s3][:-2])
+                        for ji in join_ids
+                    )
+                )
+                theta[s4] = "{}MB".format(
+                    max(
+                        10,
+                        min(
+                            int(
+                                fine_conf["runtime_theta"][f"qs{ji}"]["theta_p"][s4][
+                                    :-2
+                                ]
+                            )
+                            for ji in join_ids
+                        ),
+                    )
+                )
+                theta[s5] = str(
+                    max(
+                        int(fine_conf["runtime_theta"][f"qs{ji}"]["theta_p"][s5])
+                        for ji in join_ids
+                    )
+                )
+
             po_conf_fine_list.append(fine_conf)
             po_conf_agg_list.append(theta)
 

--- a/udao_spark/optimizer/hierarchical_optimizer.py
+++ b/udao_spark/optimizer/hierarchical_optimizer.py
@@ -34,6 +34,8 @@ from udao_spark.optimizer.utils import (
 )
 from udao_spark.utils.logging import logger
 from udao_spark.utils.monitor import DivAndConqMonitor, UdaoMonitor
+from udao_trace.parser.spark_parser import THETA_C, THETA_P, THETA_S
+from udao_trace.utils import JsonHandler
 from udao_trace.utils.interface import VarTypes
 
 
@@ -125,6 +127,7 @@ class HierarchicalOptimizer(BaseOptimizer):
         save_data_header: str = "./output",
         is_query_control: bool = False,
         benchmark: str = "tpch",
+        weights: np.ndarray = np.array([0.9, 0.1]),
     ) -> Tuple[Optional[np.ndarray], Optional[np.ndarray]]:
         self.current_target_template = template
 
@@ -171,6 +174,11 @@ class HierarchicalOptimizer(BaseOptimizer):
         len_theta_per_subQ = len_theta_c + len_theta_p + len_theta_s
 
         if "hmooc" in algo:
+            join_ids = []
+            for qs_id, v in non_decision_input.items():
+                if ".Join" in JsonHandler.dump_to_string(v["qs_lqp"]):
+                    join_ids.append(qs_id)
+            print(f"template: {template}: join_ids is {join_ids}")
             objs, conf = self._hmooc(
                 len_theta_per_subQ,
                 graph_embeddings,
@@ -189,6 +197,8 @@ class HierarchicalOptimizer(BaseOptimizer):
                 is_oracle,
                 save_data_header,
                 benchmark=benchmark,
+                join_ids=join_ids,
+                weights=weights,
             )
 
         elif algo == "evo":
@@ -312,6 +322,7 @@ class HierarchicalOptimizer(BaseOptimizer):
         is_oracle: bool,
         save_data_header: str,
         benchmark: str,
+        join_ids: List[str],
         weights: np.ndarray = np.array([1.0, 1.0]),
     ) -> Tuple[Optional[np.ndarray], Optional[np.ndarray]]:
         start = time.time()
@@ -385,13 +396,99 @@ class HierarchicalOptimizer(BaseOptimizer):
         )
 
         start_rec = time.time()
+
+        # added by chenghao to get the PO solutions with preferences directly
+        fine_conf_qs_raw = (
+            self.sc.construct_configuration(
+                po_conf.reshape(-1, len_theta_per_subQ).copy()
+            )
+            if use_ag
+            else self.sc.construct_configuration_from_norm(
+                po_conf.reshape(-1, len_theta_per_subQ).copy()
+            )
+        )
+        po_conf_fine_list = []
+        po_conf_agg_list = []
+        s3 = "spark.sql.adaptive.maxShuffledHashJoinLocalMapThreshold"
+        s4 = "spark.sql.autoBroadcastJoinThreshold"
+        s5 = "spark.sql.shuffle.partitions"
+        for i in range(po_conf.shape[0]):
+            fine_conf = {}
+            fine_conf["theta_c"] = {
+                k: v
+                for k, v in zip(THETA_C, fine_conf_qs_raw[i * n_subQs][: len(THETA_C)])
+            }
+            fine_conf["runtime_theta"] = {}
+            theta = {
+                k: v for k, v in zip(self.sc.knob_names, fine_conf_qs_raw[i * n_subQs])
+            }
+            for j in range(n_subQs):
+                qs_theta_p = {
+                    k: v
+                    for k, v in zip(
+                        THETA_P,
+                        fine_conf_qs_raw[i * n_subQs + j][
+                            len(THETA_C) : len(THETA_C) + len(THETA_P)
+                        ],
+                    )
+                }
+                qs_theta_s = {
+                    k: v
+                    for k, v in zip(
+                        THETA_S,
+                        fine_conf_qs_raw[i * n_subQs + j][
+                            len(THETA_C) + len(THETA_P) :
+                        ],
+                    )
+                }
+                if j in join_ids:
+                    theta[s3] = "{}MB".format(
+                        min(int(theta[s3][:-2]), int(qs_theta_p[s3][:-2]))
+                    )
+                    theta[s4] = "{}MB".format(
+                        max(
+                            10,
+                            min(
+                                int(theta[s4][:-2]),
+                                int(qs_theta_p[s4][:-2]),
+                            ),
+                        )
+                    )
+                    theta[s5] = str(max(int(theta[s5]), int(qs_theta_p[s5])))
+
+                fine_conf["runtime_theta"][f"qs{j}"] = {
+                    "theta_p": qs_theta_p,
+                    "theta_s": qs_theta_s,
+                }
+            po_conf_fine_list.append(fine_conf)
+            po_conf_agg_list.append(theta)
+
+        pref2theta = {}
+        pref2theta_agg = {}
+        for pref in [
+            (0, 1),
+            (0.1, 0.9),
+            (0.5, 0.5),
+            (0.9, 0.1),
+            (1, 0),
+        ]:
+            objs, conf_fine = weighted_utopia_nearest(
+                po_objs, np.array(po_conf_fine_list), np.array(pref)
+            )
+            objs, conf_agg = weighted_utopia_nearest(
+                po_objs, np.array(po_conf_agg_list), np.array(pref)
+            )
+            pref2theta[f"{pref[0]:.1f}_{pref[1]:.1f}"] = conf_fine
+            pref2theta_agg[f"{pref[0]:.1f}_{pref[1]:.1f}"] = conf_agg
+            print(f"weights: {pref}, objs: {objs}, conf: {conf_agg}")
+
         conf_qs0 = po_conf[:, :len_theta_per_subQ].reshape(-1, len_theta_per_subQ)
         conf_all_qs = np.vstack(np.split(po_conf, n_subQs, axis=1))
         if use_ag:
-            conf_raw = self.sc.construct_configuration(conf_qs0).reshape(
+            conf_raw = self.sc.construct_configuration(conf_qs0.copy()).reshape(
                 -1, len_theta_per_subQ
             )
-            conf_raw_all = self.sc.construct_configuration(conf_all_qs).reshape(
+            conf_raw_all = self.sc.construct_configuration(conf_all_qs.copy()).reshape(
                 -1, len_theta_per_subQ
             )
             if n_c_samples == 1:
@@ -427,7 +524,9 @@ class HierarchicalOptimizer(BaseOptimizer):
                 )
 
         # add WUN
-        objs, conf = weighted_utopia_nearest(po_objs, conf_raw, weights)
+        objs, conf = weighted_utopia_nearest(
+            po_objs, np.array(po_conf_agg_list), weights
+        )
         tc_po_rec = time.time() - start_rec
         print(f"FUNCTION: time cost of {algo} with WUN " f"is: {tc_po_rec}")
 
@@ -446,7 +545,12 @@ class HierarchicalOptimizer(BaseOptimizer):
             save_json(data_path, time_cost_dict, mode="time_cost_json")
             save_json(data_path, total_time_profile, mode="time_profile")
 
-        return conf, objs
+            JsonHandler.dump_to_file(pref2theta, f"{data_path}/pref2theta.json", 2)
+            JsonHandler.dump_to_file(
+                pref2theta_agg, f"{data_path}/pref2theta_agg.json", 2
+            )
+
+        return objs, conf
 
     def _evo(
         self,

--- a/udao_spark/optimizer/hierarchical_optimizer.py
+++ b/udao_spark/optimizer/hierarchical_optimizer.py
@@ -455,7 +455,7 @@ class HierarchicalOptimizer(BaseOptimizer):
             if len(join_ids) > 0:
                 theta[s3] = "{}MB".format(
                     min(
-                        int(fine_conf["runtime_theta"][f"qs{ji}"]["theta_p"][s3][:-2])
+                        int(fine_conf["runtime_theta"][ji]["theta_p"][s3][:-2])
                         for ji in join_ids
                     )
                 )
@@ -463,18 +463,14 @@ class HierarchicalOptimizer(BaseOptimizer):
                     max(
                         10,
                         min(
-                            int(
-                                fine_conf["runtime_theta"][f"qs{ji}"]["theta_p"][s4][
-                                    :-2
-                                ]
-                            )
+                            int(fine_conf["runtime_theta"][ji]["theta_p"][s4][:-2])
                             for ji in join_ids
                         ),
                     )
                 )
                 theta[s5] = str(
                     max(
-                        int(fine_conf["runtime_theta"][f"qs{ji}"]["theta_p"][s5])
+                        int(fine_conf["runtime_theta"][ji]["theta_p"][s5])
                         for ji in join_ids
                     )
                 )

--- a/udao_spark/optimizer/hierarchical_optimizer.py
+++ b/udao_spark/optimizer/hierarchical_optimizer.py
@@ -1074,6 +1074,18 @@ class HierarchicalOptimizer(BaseOptimizer):
                     [50, 75],  # 2
                 ]
 
+            elif n_c_samples == 360:  # 4  2  5  1  2 * 2 = 360
+                c_grids = [
+                    [1, 2, 3, 4, 5],  # 5
+                    [1, 2, 3],  # 3
+                    [6, 8, 10, 12, 14, 16],  # 6
+                    [2],
+                    [2],
+                    [0, 1],  # 2
+                    [1],
+                    [50, 75],  # 2
+                ]
+
             elif n_c_samples == 64:
                 if "test_end" in save_data_header:
                     # to test for end-to-end
@@ -1208,6 +1220,20 @@ class HierarchicalOptimizer(BaseOptimizer):
                     [1, 2, 3],
                     [1, 2],  # default
                 ]
+
+            elif n_p_samples == 324:  # 2 3  3  3  3  2 = 162
+                p_grids = [
+                    [2, 4],  # default
+                    [2],  # default
+                    [0, 14, 28],  # 0MB/160MB maxShuffledHashJoinLocalMapThreshold
+                    [0, 14, 28],  # 0MB/160MB autoBroadcastJoinThreshold
+                    [10, 20, 40],  # 80/160/320 sql.shuffle.partitions
+                    [2],
+                    [50],  # default
+                    [1, 2, 3],
+                    [1, 2],  # default
+                ]
+
             elif n_p_samples == 128:
                 p_grids = [
                     [0],

--- a/udao_spark/optimizer/utils.py
+++ b/udao_spark/optimizer/utils.py
@@ -205,14 +205,16 @@ def even_weights(stepsize: float, m: int) -> List[Any]:
 def weighted_utopia_nearest(
     pareto_objs: np.ndarray,
     pareto_confs: np.ndarray,
-    weights: np.ndarray,
+    weights: np.ndarray = np.array([1, 1]),
 ) -> Tuple[np.ndarray, np.ndarray]:
     """
     return the Pareto point that is closest to the utopia point
     in a weighted distance function
     """
     n_pareto = pareto_objs.shape[0]
-    assert n_pareto > 0
+    if n_pareto == 0:
+        logger.error("No Pareto point, return None")
+        raise ValueError("No Pareto point, return None")
     if n_pareto == 1:
         # (2,), (n, 2)
         return pareto_objs[0], pareto_confs[0]
@@ -256,36 +258,6 @@ def utopia_nearest(
     distances = np.linalg.norm(po_objs_norm, axis=1)
     un_ind = np.argmin(distances)
     return po_objs[un_ind], po_confs[un_ind]
-
-
-def weighted_utopia_nearest_impl(
-    pareto_objs: np.ndarray, pareto_confs: np.ndarray
-) -> Tuple[np.ndarray, np.ndarray]:
-    """
-    return the Pareto point that is closest to the utopia point
-    in a weighted distance function
-    """
-    n_pareto = pareto_objs.shape[0]
-    assert n_pareto > 0
-    if n_pareto == 1:
-        # (2,), (n, 2)
-        return pareto_objs[0], pareto_confs[0]
-
-    utopia = np.zeros_like(pareto_objs[0])
-    min_objs, max_objs = pareto_objs.min(0), pareto_objs.max(0)
-    pareto_norm = (pareto_objs - min_objs) / (max_objs - min_objs)
-    # fixme: internal weights
-    weights = np.array([1, 1])
-    # weights = np.array([0.7, 0.3])
-    pareto_weighted_norm = pareto_norm * weights
-    # check the speed comparison: https://stackoverflow.com/a/37795190/5338690
-    dists = np.sum((pareto_weighted_norm - utopia) ** 2, axis=1)
-    wun_id = np.argmin(dists)
-
-    picked_pareto = pareto_objs[wun_id]
-    picked_confs = pareto_confs[wun_id]
-
-    return picked_pareto, picked_confs
 
 
 class Model:

--- a/udao_spark/optimizer/utils.py
+++ b/udao_spark/optimizer/utils.py
@@ -12,7 +12,6 @@ from udao.optimization.concepts.utils import InputParameters, InputVariables
 from udao_trace.utils import JsonHandler
 
 from ..model.utils import get_graph_ckp_info
-from ..utils.constants import EPS
 from ..utils.logging import logger
 from ..utils.params import QType
 
@@ -230,34 +229,6 @@ def weighted_utopia_nearest(
     picked_confs = pareto_confs[wun_id]
 
     return picked_pareto, picked_confs
-
-
-def utopia_nearest(
-    po_objs: np.ndarray,
-    po_confs: np.ndarray,
-) -> Tuple[Optional[np.ndarray], Optional[np.ndarray]]:
-    """
-    return the Pareto point that is closest to the utopia point
-    """
-    if po_objs.ndim != 2 or po_confs.ndim != 2:
-        raise ValueError("po_objs and po_confs should be 2D arrays")
-    if len(po_objs) == 0:
-        logger.error("No Pareto point, return None")
-        return None, None
-    if len(po_objs) == 1:
-        logger.warning("Only one Pareto point, return it directly")
-        return po_objs[0], po_confs[0]
-    if po_objs.dtype != np.float32:
-        po_objs = po_objs.astype(np.float32)
-
-    objs_min, objs_max = po_objs.min(axis=0), po_objs.max(axis=0)
-    objs_range = objs_max - objs_min
-    objs_range[np.where(objs_range == 0)] = EPS
-    po_objs_norm = (po_objs - objs_min) / objs_range
-    # after normalization, the utopia point locates at [0, 0]
-    distances = np.linalg.norm(po_objs_norm, axis=1)
-    un_ind = np.argmin(distances)
-    return po_objs[un_ind], po_confs[un_ind]
 
 
 class Model:

--- a/udao_spark/optimizer/utils.py
+++ b/udao_spark/optimizer/utils.py
@@ -224,7 +224,7 @@ def weighted_utopia_nearest(
     pareto_norm = (pareto_objs - min_objs) / (max_objs - min_objs)
     pareto_weighted_norm = pareto_norm * weights
     dists = np.sum((pareto_weighted_norm - utopia) ** 2, axis=1)
-    wun_id = np.argmin(dists)
+    wun_id = int(np.argmin(dists))
 
     picked_pareto = pareto_objs[wun_id]
     picked_confs = pareto_confs[wun_id]

--- a/udao_spark/tests/test_optimizer.py
+++ b/udao_spark/tests/test_optimizer.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from ..optimizer.utils import utopia_nearest
+from ..optimizer.utils import weighted_utopia_nearest
 
 
 def test_utopia_nearest() -> None:
@@ -39,5 +39,5 @@ def test_utopia_nearest() -> None:
             ["0.11", "1024KB"],
         ]
     )
-    ret = utopia_nearest(po_objs, po_confs)
+    ret = weighted_utopia_nearest(po_objs, po_confs, weights=np.array([1, 1]))
     assert ret is not None

--- a/udao_spark/utils/params.py
+++ b/udao_spark/utils/params.py
@@ -268,6 +268,10 @@ def get_compile_time_optimizer_parameters() -> ArgumentParser:
     parser.add_argument("--set_query_control", action="store_true",
                         help="Enable query-level control, "
                              "which is fine-grained control by default")
+    parser.add_argument("--weights", nargs="+", type=int,
+                        default=[0.9, 0.1])
+    parser.add_argument("--conf_save", type=str,
+                        default="chenghao_conf_save")
 
     # fmt: on
     return parser


### PR DESCRIPTION
1. add additional hard-coded grid-search settings to support profiling the sampling rate
2. support auto-expose the configuration in a separate file to bypass the manual configuration selection.
3. unify the `weighted_utopia_nearest` related functions into a general one.