### PR TITLE
add new grids

### DIFF
--- a/playground/compile_time_hierarchical_optimizer_adaptive_profiling.py
+++ b/playground/compile_time_hierarchical_optimizer_adaptive_profiling.py
@@ -23,6 +23,7 @@ def get_params() -> argparse.ArgumentParser:
     parser = get_compile_time_optimizer_parameters()
     parser.add_argument("--target_templates", nargs="+", type=str, default=None)
     parser.add_argument("--ordered_queries_header", type=str, default="assets")
+    parser.add_argument("--weights", nargs="+", type=float, default=[0.9, 0.1])
     return parser
 
 
@@ -158,7 +159,7 @@ if __name__ == "__main__":
             non_decision_input = get_non_decision_inputs_for_qs_compile_dict(
                 trace, is_oracle=is_oracle
             )
-            po_objs, po_conf = hier_optimizer.solve(
+            po_objs, po_conf, dt = hier_optimizer.solve(
                 template=query_id.split("-")[0],
                 non_decision_input=non_decision_input,
                 seed=params.seed,
@@ -174,9 +175,7 @@ if __name__ == "__main__":
                 save_data_header=params.save_data_header,
                 is_query_control=params.set_query_control,
                 benchmark=bm,
-                weights=np.array(params.weights),
                 selected_features=selected_features,
-                return_pareto_set=True,
             )
             if po_objs is None or po_conf is None:
                 logger.warning(f"Failed to solve {query_id}")

--- a/playground/compile_time_optimizer.py
+++ b/playground/compile_time_optimizer.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
         query_id = f"{template}-1"
         non_decision_input = get_non_decision_inputs_for_q_compile(trace)
         monitor = UdaoMonitor()
-        po_objs, po_confs = atomic_optimizer.solve(
+        po_objs, po_confs, _ = atomic_optimizer.solve(
             template=template,
             non_decision_input=non_decision_input,
             seed=params.seed,

--- a/playground/scripts/run_compile_time_hierarchical_optimizer.sh
+++ b/playground/scripts/run_compile_time_hierarchical_optimizer.sh
@@ -63,11 +63,15 @@ if [ "$bm" = "tpch" ]; then
   for weights in "0.0_1.0" "0.9_0.1" "0.5_0.5" "0.1_0.9" "1.0_0.0"; do
     scp chenghao_conf_save/tpch100/hmooc%B_${sample_mode}/${fname}_${weights}.json \
     hex1@node1:~/chenghao/udao-spark-optimizer/playground/evaluations/tpch100/divB_new_grids/on_demand/${sample_mode}_${fname}_${weights}.json
+    scp chenghao_conf_save/tpch100/pref_to_df_hmooc%B_${sample_mode}_${fname}_${weights}.pkl \
+    hex1@node1:~/chenghao/udao-spark-optimizer/playground/evaluations/tpch100/divB_new_grids
   done
 elif [ "$bm" = "tpcds" ]; then
   for weights in "0.0_1.0" "0.9_0.1" "0.5_0.5" "0.1_0.9" "1.0_0.0"; do
     scp chenghao_conf_save/tpcds100/hmooc%B_${sample_mode}/${fname}_${weights}.json \
     hex2@node7:~/chenghao/udao-spark-optimizer/playground/evaluations/tpcds100/divB_new_grids/on_demand/${sample_mode}_${fname}_${weights}.json
+    scp chenghao_conf_save/tpcds100/pref_to_df_hmooc%B_${sample_mode}_${fname}_${weights}.pkl \
+    hex2@node7:~/chenghao/udao-spark-optimizer/playground/evaluations/tpcds100/divB_new_grids
   done
 else
     echo "Invalid benchmark specified"

--- a/playground/scripts/run_compile_time_hierarchical_optimizer.sh
+++ b/playground/scripts/run_compile_time_hierarchical_optimizer.sh
@@ -1,0 +1,75 @@
+bm=$1
+sample_mode=$2
+nc=$3
+np=$4
+selected=${5:-0}
+
+# Constructing the base command based on the value of bm
+if [ "$bm" = "tpch" ]; then
+    cmd="python compile_time_hierarchical_optimizer.py \
+        --q_type qs_lqp_compile \
+        --ag_model_qs_ana_latency \"WeightedEnsemble_L2_FULL\" \
+        --ag_model_qs_io \"CatBoost\" \
+        --graph_choice gtn \
+        --infer_limit 1e-5 \
+        --infer_limit_batch_size 10000 \
+        --ag_time_limit 21600 \
+        --ag_sign \"high_quality\" \
+        --moo_algo \"hmooc%B\" \
+        --n_c_samples $nc \
+        --n_p_samples $np \
+        --sample_mode $sample_mode \
+        --save_data \
+        --save_data_header \"./output/\" \
+        --clf_recall_xhold -1"
+elif [ "$bm" = "tpcds" ]; then
+    cmd="python compile_time_hierarchical_optimizer.py \
+        --benchmark tpcds \
+        --q_type qs_lqp_compile \
+        --ag_model_qs_ana_latency \"WeightedEnsemble_L3_FULL\" \
+        --ag_model_qs_io \"CatBoost\" \
+        --graph_choice gtn \
+        --infer_limit 1e-5 \
+        --infer_limit_batch_size 10000 \
+        --ag_time_limit 10800 \
+        --ag_sign \"high_quality\" \
+        --moo_algo \"hmooc%B\" \
+        --n_c_samples $nc \
+        --n_p_samples $np \
+        --sample_mode $sample_mode \
+        --save_data \
+        --save_data_header \"./output/\" \
+        --clf_recall_xhold -1"
+else
+    echo "Invalid benchmark specified"
+    exit 1
+fi
+
+# Adding --selected_features if selected is true (1)
+if [ "$selected" -eq 1 ]; then
+    cmd="$cmd --selected_features"
+fi
+
+# Running the constructed command
+eval $cmd
+
+# Constructing the base command based on the value of bm
+fname=nc${nc}_np${np}
+if [ "$selected" -eq 1 ]; then
+    fname="selected_params_${fname}"
+fi
+
+if [ "$bm" = "tpch" ]; then
+  for weights in "0.0_1.0" "0.9_0.1" "0.5_0.5" "0.1_0.9" "1.0_0.0"; do
+    scp chenghao_conf_save/tpch100/hmooc%B_${sample_mode}/${fname}_${weights}.json \
+    hex1@node1:~/chenghao/udao-spark-optimizer/playground/evaluations/tpch100/divB_new_grids/on_demand/${sample_mode}_${fname}_${weights}.json
+  done
+elif [ "$bm" = "tpcds" ]; then
+  for weights in "0.0_1.0" "0.9_0.1" "0.5_0.5" "0.1_0.9" "1.0_0.0"; do
+    scp chenghao_conf_save/tpcds100/hmooc%B_${sample_mode}/${fname}_${weights}.json \
+    hex2@node7:~/chenghao/udao-spark-optimizer/playground/evaluations/tpcds100/divB_new_grids/on_demand/${sample_mode}_${fname}_${weights}.json
+  done
+else
+    echo "Invalid benchmark specified"
+    exit 1
+fi

--- a/playground/scripts/run_compile_time_hierarchical_optimizer_adaptive_profiling.sh
+++ b/playground/scripts/run_compile_time_hierarchical_optimizer_adaptive_profiling.sh
@@ -1,0 +1,85 @@
+bm=$1
+templates=$2
+sample_mode=$3
+nc=$4
+np=$5
+selected=${6:-0}
+
+# Constructing the base command based on the value of bm
+if [ "$bm" = "tpch" ]; then
+    cmd="python compile_time_hierarchical_optimizer_adaptive_profiling.py \
+        --q_type qs_lqp_compile \
+        --ag_model_qs_ana_latency \"WeightedEnsemble_L2_FULL\" \
+        --ag_model_qs_io \"CatBoost\" \
+        --graph_choice gtn \
+        --infer_limit 1e-5 \
+        --infer_limit_batch_size 10000 \
+        --ag_time_limit 21600 \
+        --ag_sign \"high_quality\" \
+        --moo_algo \"hmooc%B\" \
+        --n_c_samples $nc \
+        --n_p_samples $np \
+        --sample_mode $sample_mode \
+        --save_data_header \"./output/\" \
+        --clf_recall_xhold -1"
+elif [ "$bm" = "tpcds" ]; then
+    cmd="python compile_time_hierarchical_optimizer_adaptive_profiling.py \
+        --benchmark tpcds \
+        --q_type qs_lqp_compile \
+        --ag_model_qs_ana_latency \"WeightedEnsemble_L3_FULL\" \
+        --ag_model_qs_io \"CatBoost\" \
+        --graph_choice gtn \
+        --infer_limit 1e-5 \
+        --infer_limit_batch_size 10000 \
+        --ag_time_limit 10800 \
+        --ag_sign \"high_quality\" \
+        --moo_algo \"hmooc%B\" \
+        --n_c_samples $nc \
+        --n_p_samples $np \
+        --sample_mode $sample_mode \
+        --save_data_header \"./output/\" \
+        --clf_recall_xhold -1"
+else
+    echo "Invalid benchmark specified"
+    exit 1
+fi
+
+if [ "$templates" != "all" ]; then
+    cmd="$cmd --target_templates $templates"
+fi
+
+# Adding --selected_features if selected is true (1)
+if [ "$selected" -eq 1 ]; then
+    cmd="$cmd --selected_features"
+fi
+
+
+# Running the constructed command
+eval $cmd
+
+# Constructing the base command based on the value of bm
+fname=nc${nc}_np${np}
+if [ "$selected" -eq 1 ]; then
+    fname="selected_params_${fname}"
+fi
+fname="adaptive_${fname}"
+suffix=$(echo "$templates" | tr ' ' '+')
+
+if [ "$bm" = "tpch" ]; then
+  for weights in "0.0_1.0" "0.9_0.1" "0.5_0.5" "0.1_0.9" "1.0_0.0"; do
+    scp chenghao_conf_save/tpch100/hmooc%B_${sample_mode}/${fname}_${weights}_${suffix}_distinct.json \
+    hex1@node1:~/chenghao/udao-spark-optimizer/playground/evaluations/tpch100/divB_new_grids/on_demand/${sample_mode}_${fname}_${weights}_${suffix}_distinct.json
+#    scp chenghao_conf_save/tpch100/pref_to_df_hmooc%B_${sample_mode}_${fname}_${weights}.pkl \
+#    hex1@node1:~/chenghao/udao-spark-optimizer/playground/evaluations/tpch100/divB_new_grids
+  done
+elif [ "$bm" = "tpcds" ]; then
+  for weights in "0.0_1.0" "0.9_0.1" "0.5_0.5" "0.1_0.9" "1.0_0.0"; do
+    scp chenghao_conf_save/tpcds100/hmooc%B_${sample_mode}/${fname}_${weights}_${suffix}_distinct.json \
+    hex2@node7:~/chenghao/udao-spark-optimizer/playground/evaluations/tpcds100/divB_new_grids/on_demand/${sample_mode}_${fname}_${weights}_${suffix}_distinct.json
+#    scp chenghao_conf_save/tpcds100/pref_to_df_hmooc%B_${sample_mode}_${fname}_${weights}.pkl \
+#    hex2@node7:~/chenghao/udao-spark-optimizer/playground/evaluations/tpcds100/divB_new_grids
+  done
+else
+    echo "Invalid benchmark specified"
+    exit 1
+fi

--- a/udao_spark/optimizer/atomic_optimizer.py
+++ b/udao_spark/optimizer/atomic_optimizer.py
@@ -53,7 +53,7 @@ class AtomicOptimizer(BaseOptimizer):
         ercilla: bool = True,
         graph_choice: str = "gtn",
         selected_features: Optional[Dict[str, List[str]]] = None,
-    ) -> Tuple[Optional[np.ndarray], Optional[np.ndarray]]:
+    ) -> Tuple[Optional[np.ndarray], Optional[np.ndarray], float]:
         non_decision_dict = self.extract_data_and_compute_non_decision_features(
             monitor, non_decision_input, use_ag, ercilla, graph_choice
         )
@@ -136,7 +136,7 @@ class AtomicOptimizer(BaseOptimizer):
 
         n_po = len(po_objs)
         if n_po == 0:
-            return None, None
+            return None, None, -1
 
         logger.debug(f"po_objs: {po_objs}, po_theta: {po_theta}")
         po_confs = self.construct_po_confs(po_theta, use_ag)
@@ -147,4 +147,4 @@ class AtomicOptimizer(BaseOptimizer):
         if self.verbose:
             logger.info(f">> constructed configurations in {(t7 - t6) / 1e6} ms")
 
-        return po_objs, po_confs
+        return po_objs, po_confs, -1

--- a/udao_spark/optimizer/base_optimizer.py
+++ b/udao_spark/optimizer/base_optimizer.py
@@ -671,7 +671,7 @@ class BaseOptimizer(ABC):
         non_decision_input: Dict[str, Any],
         seed: Optional[int] = None,
         use_ag: bool = True,
-    ) -> Tuple[Optional[np.ndarray], Optional[np.ndarray]]:
+    ) -> Tuple[Optional[np.ndarray], Optional[np.ndarray], float]:
         pass
 
     def weighted_utopia_nearest(self, pareto_points: List[Point]) -> Point:

--- a/udao_spark/optimizer/hierarchical_optimizer.py
+++ b/udao_spark/optimizer/hierarchical_optimizer.py
@@ -1684,12 +1684,12 @@ class HierarchicalOptimizer(BaseOptimizer):
                 #
                 # k7, k1, k3, k2 (set k2, k4, k6, k5 and k8 to default)
                 # s4, s5, s8, s9, s1 (set s2, s3, s6, s7 to default)
-                if n_c_samples not in [32, 128]:
+                if n_c_samples not in [32, 54, 128]:
                     raise Exception(
                         f"# of theta_c samples {n_c_samples} "
                         f"is not supported for {sample_mode}!"
                     )
-                if n_p_samples not in [32, 64, 128]:
+                if n_p_samples not in [32, 64, 81, 128, 243]:
                     raise Exception(
                         f"# of theta_p samples {n_p_samples} "
                         f"is not supported for {sample_mode}!"
@@ -1699,6 +1699,17 @@ class HierarchicalOptimizer(BaseOptimizer):
                         [1, 5],  # k1
                         [1, 4],  # k2
                         [4, 8, 12, 16],  # k3
+                        [2],  # k4 - from best practice
+                        [2],  # k5 - default: 2
+                        [0],  # k6 - set to "0"
+                        [0, 1],  # k7
+                        [60],  # k8 - default: 60
+                    ]
+                elif n_c_samples == 54:  # chosen <- 3-value strateg
+                    c_grids = [
+                        [1, 3, 5],  # k1
+                        [1, 2, 3],  # k2
+                        [4, 10, 16],  # k3
                         [2],  # k4 - from best practice
                         [2],  # k5 - default: 2
                         [0],  # k6 - set to "0"
@@ -1722,8 +1733,9 @@ class HierarchicalOptimizer(BaseOptimizer):
                         f"is not supported for {sample_mode}!"
                     )
 
+                # s4, s5, s8, s9, s1 (set s2, s3, s6, s7 to default)
                 # for some realistic concerns, we reset the range for
-                # s4: [1MB - 280MB] to avoid failures and missing good broadcast
+                # s4: [0MB - 280MB] to avoid failures and missing good broadcast
                 # s5: [10 - 50] to avoid bad performance within same resource usage
                 if n_p_samples == 32:
                     p_grids = [
@@ -1749,7 +1761,31 @@ class HierarchicalOptimizer(BaseOptimizer):
                         [0, 4],  # s8: spark.sql.files.maxPartitionBytes
                         [0, 4],  # s9: default
                     ]
-                elif n_p_samples == 128:
+                elif n_p_samples == 81:  # 3^4 = 81
+                    p_grids = [
+                        [2],  # s1 <--
+                        [2],  # s2 default
+                        [0],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
+                        [0, 14, 28],  # s4: 10MB/280MB autoBroadcastJoinThreshold
+                        [10, 20, 50],  # s5: 80/400 sql.shuffle.partitions
+                        [2],  # s6 default
+                        [50],  # s7: default
+                        [0, 2, 4],  # s8: spark.sql.files.maxPartitionBytes
+                        [0, 2, 4],  # s9: default <--
+                    ]
+                elif n_p_samples == 243:  # 3^5 = 243
+                    p_grids = [
+                        [0, 2, 5],  # s1 <--
+                        [2],  # s2 default
+                        [0],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
+                        [0, 14, 28],  # s4: 10MB/280MB autoBroadcastJoinThreshold
+                        [10, 20, 50],  # s5: 80/400 sql.shuffle.partitions
+                        [2],  # s6 default
+                        [50],  # s7: default
+                        [0, 2, 4],  # s8: spark.sql.files.maxPartitionBytes
+                        [0, 2, 4],  # s9: default <--
+                    ]
+                elif n_p_samples == 128:  #
                     p_grids = [
                         [0, 5],  # s1
                         [2],  # s2 default

--- a/udao_spark/optimizer/hierarchical_optimizer.py
+++ b/udao_spark/optimizer/hierarchical_optimizer.py
@@ -1709,11 +1709,11 @@ class HierarchicalOptimizer(BaseOptimizer):
                     c_grids = [
                         [1, 3, 5],  # k1
                         [1, 2, 3],  # k2
-                        [4, 10, 16],  # k3
+                        [4, 10, 16],  # k3 -> Fixme: diff
                         [2],  # k4 - from best practice
                         [2],  # k5 - default: 2
                         [0],  # k6 - set to "0"
-                        [0, 1],  # k7
+                        [0, 1],  # k7 -> Fixme: diff
                         [60],  # k8 - default: 60
                     ]
                 elif n_c_samples == 128:
@@ -1770,8 +1770,12 @@ class HierarchicalOptimizer(BaseOptimizer):
                         [10, 20, 50],  # s5: 80/400 sql.shuffle.partitions
                         [2],  # s6 default
                         [50],  # s7: default
-                        [0, 2, 4],  # s8: spark.sql.files.maxPartitionBytes
-                        [0, 2, 4],  # s9: default <--
+                        [
+                            0,
+                            2,
+                            4,
+                        ],  # s8: spark.sql.files.maxPartitionBytes <-- fixme: diff
+                        [0, 2, 4],  # s9: default <-- fixme: diff
                     ]
                 elif n_p_samples == 243:  # 3^5 = 243
                     p_grids = [
@@ -1796,6 +1800,65 @@ class HierarchicalOptimizer(BaseOptimizer):
                         [50],  # s7: default
                         [0, 4],  # s8: spark.sql.files.maxPartitionBytes
                         [0, 4],  # s9: default
+                    ]
+                else:
+                    raise Exception(
+                        f"# of theta_p samples {n_p_samples} "
+                        f"is not supported for {sample_mode}!"
+                    )
+            elif sample_mode == "grid-adaptive-cut-Cum5P-2":
+                # the choices of grid based on the selected importance of the knobs
+                # set default to parameters from the low rank to the high rank
+                # that cumulatively sum up to 5% of WMAPE
+                #
+                # k7, k1, k3, k2 (set k2, k4, k6, k5 and k8 to default)
+                # s4, s5, s8, s9, s1 (set s2, s3, s6, s7 to default)
+                if n_c_samples not in [54]:
+                    raise Exception(
+                        f"# of theta_c samples {n_c_samples} "
+                        f"is not supported for {sample_mode}!"
+                    )
+                if n_p_samples not in [81]:
+                    raise Exception(
+                        f"# of theta_p samples {n_p_samples} "
+                        f"is not supported for {sample_mode}!"
+                    )
+                if n_c_samples == 54:  # chosen <- 3-value strateg
+                    c_grids = [
+                        [1, 3, 5],  # k1
+                        [1, 2, 3],  # k2
+                        [4, 10, 16],  # k3 -> Fixme: diff
+                        [2],  # k4 - from best practice
+                        [2],  # k5 - default: 2
+                        [0],  # k6 - set to "0"
+                        [0, 1],  # k7 -> Fixme: diff
+                        [60],  # k8 - default: 60
+                    ]
+                else:
+                    raise Exception(
+                        f"# of theta_c samples {n_c_samples} "
+                        f"is not supported for {sample_mode}!"
+                    )
+
+                # s4, s5, s8, s9, s1 (set s2, s3, s6, s7 to default)
+                # for some realistic concerns, we reset the range for
+                # s4: [0MB - 280MB] to avoid failures and missing good broadcast
+                # s5: [10 - 50] to avoid bad performance within same resource usage
+                if n_p_samples == 81:  # 3^4 = 81
+                    p_grids = [
+                        [2],  # s1 <--
+                        [2],  # s2 default
+                        [0],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
+                        [0, 14, 28],  # s4: 10MB/280MB autoBroadcastJoinThreshold
+                        [10, 20, 50],  # s5: 80/400 sql.shuffle.partitions
+                        [2],  # s6 default
+                        [50],  # s7: default
+                        [
+                            1,
+                            2,
+                            3,
+                        ],  # s8: spark.sql.files.maxPartitionBytes <-- fixme: diff
+                        [0, 2, 4],  # s9: default <-- fixme: diff
                     ]
                 else:
                     raise Exception(

--- a/udao_spark/optimizer/hierarchical_optimizer.py
+++ b/udao_spark/optimizer/hierarchical_optimizer.py
@@ -1468,541 +1468,7 @@ class HierarchicalOptimizer(BaseOptimizer):
                     ]
                 else:
                     raise Exception(f"n_p_samples {n_p_samples} is not supported!")
-
-            elif sample_mode == "grid-adaptive-cut-1P":
-                # the choices of grid based on the selected importance of the knobs
-                # k7, k1, k3, k2, k4, k6 (set k5 and k8 to default)
-                # s4, s5, s8, s9, s1 (set s2, s3, s6, s7 to default)
-                # adjust
-                if n_c_samples not in [32, 64, 128, 256, 512]:
-                    raise Exception(
-                        f"# of theta_c samples {n_c_samples} "
-                        f"is not supported for {sample_mode}!"
-                    )
-                if n_p_samples not in [32, 64, 128]:
-                    raise Exception(
-                        f"# of theta_p samples {n_p_samples} "
-                        f"is not supported for {sample_mode}!"
-                    )
-                if n_c_samples == 32:
-                    c_grids = [
-                        [1, 5],  # k1
-                        [1, 4],  # k2
-                        [4, 16],  # k3
-                        [1, 4],  # k4
-                        [2],  # k5 - default: 2
-                        [0],  # k6 - set to "0"
-                        [0, 1],  # k7
-                        [60],  # k8 - default: 60
-                    ]
-                elif n_c_samples == 64:
-                    c_grids = [
-                        [1, 5],  # k1
-                        [1, 4],  # k2
-                        [4, 16],  # k3
-                        [1, 4],  # k4
-                        [2],  # k5 - default: 2
-                        [0, 1],  # k6
-                        [0, 1],  # k7
-                        [60],  # k8 - default: 60
-                    ]
-                elif n_c_samples == 128:
-                    c_grids = [
-                        [1, 2, 4, 5],  # k1
-                        [1, 4],  # k2
-                        [4, 16],  # k3
-                        [1, 4],  # k4
-                        [2],  # k5 - default: 2
-                        [0, 1],  # k6
-                        [0, 1],  # k7
-                        [60],  # k8 - default: 60
-                    ]
-                elif n_c_samples == 256:
-                    c_grids = [
-                        [1, 2, 4, 5],  # k1
-                        [1, 4],  # k2
-                        [4, 8, 12, 16],  # k3
-                        [1, 4],  # k4
-                        [2],  # k5 - default: 2
-                        [0, 1],  # k6
-                        [0, 1],  # k7
-                        [60],  # k8 - default: 60
-                    ]
-                elif n_c_samples == 512:
-                    c_grids = [
-                        [1, 2, 4, 5],  # k1
-                        [1, 2, 3, 4],  # k2
-                        [4, 8, 12, 16],  # k3
-                        [1, 4],  # k4
-                        [2],  # k5 - default: 2
-                        [0, 1],  # k6
-                        [0, 1],  # k7
-                        [60],  # k8 - default: 60
-                    ]
-                else:
-                    raise Exception(
-                        f"# of theta_c samples {n_c_samples} "
-                        f"is not supported for {sample_mode}!"
-                    )
-
-                # for some realistic concerns, we reset the range for
-                # s4: [1MB - 280MB] to avoid failures and missing good broadcast
-                # s5: [10 - 50] to avoid bad performance within same resource usage
-                if n_p_samples == 32:
-                    p_grids = [
-                        [0, 5],  # s1
-                        [2],  # s2 default
-                        [0],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
-                        [1, 28],  # s4: 10MB/280MB autoBroadcastJoinThreshold
-                        [10, 50],  # s5: 80/400 sql.shuffle.partitions
-                        [2],  # s6 default
-                        [50],  # s7: default
-                        [0, 4],  # s8: spark.sql.files.maxPartitionBytes
-                        [0, 4],  # s9: default
-                    ]
-                elif n_p_samples == 64:
-                    p_grids = [
-                        [0, 5],  # s1
-                        [2],  # s2 default
-                        [0],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
-                        [1, 4, 14, 28],  # s4: 10MB/280MB autoBroadcastJoinThreshold
-                        [10, 50],  # s5: 80/400 sql.shuffle.partitions
-                        [2],  # s6 default
-                        [50],  # s7: default
-                        [0, 4],  # s8: spark.sql.files.maxPartitionBytes
-                        [0, 4],  # s9: default
-                    ]
-                elif n_p_samples == 128:
-                    p_grids = [
-                        [0, 5],  # s1
-                        [2],  # s2 default
-                        [0],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
-                        [1, 4, 14, 28],  # s4: 10MB/280MB autoBroadcastJoinThreshold
-                        [10, 20, 40, 50],  # s5: 80/400 sql.shuffle.partitions
-                        [2],  # s6 default
-                        [50],  # s7: default
-                        [0, 4],  # s8: spark.sql.files.maxPartitionBytes
-                        [0, 4],  # s9: default
-                    ]
-                else:
-                    raise Exception(
-                        f"# of theta_p samples {n_p_samples} "
-                        f"is not supported for {sample_mode}!"
-                    )
-
-            elif sample_mode == "grid-adaptive-cut-5P":
-                # the choices of grid based on the selected importance of the knobs
-                # k7, k1, k3 (set k2, k4, k6, k5 and k8 to default)
-                # s4, s5, s8 (set s9, s1, s2, s3, s6, s7 to default)
-                if n_c_samples not in [32, 128]:
-                    raise Exception(
-                        f"# of theta_c samples {n_c_samples} "
-                        f"is not supported for {sample_mode}!"
-                    )
-                if n_p_samples not in [32, 64, 128]:
-                    raise Exception(
-                        f"# of theta_p samples {n_p_samples} "
-                        f"is not supported for {sample_mode}!"
-                    )
-                if n_c_samples == 32:
-                    c_grids = [
-                        [1, 2, 4, 5],  # k1
-                        [1],  # k2
-                        [4, 8, 12, 16],  # k3
-                        [2],  # k4 - from best practice
-                        [2],  # k5 - default: 2
-                        [0],  # k6 - set to "0"
-                        [0, 1],  # k7
-                        [60],  # k8 - default: 60
-                    ]
-                elif n_c_samples == 128:
-                    c_grids = [
-                        [1, 2, 4, 5],  # k1
-                        [1, 2, 3, 4],  # k2
-                        [4, 8, 12, 16],  # k3
-                        [2],  # k4 - from best practice
-                        [2],  # k5 - default: 2
-                        [0],  # k6 - set to "0"
-                        [0, 1],  # k7
-                        [60],  # k8 - default: 60
-                    ]
-                else:
-                    raise Exception(
-                        f"# of theta_c samples {n_c_samples} "
-                        f"is not supported for {sample_mode}!"
-                    )
-
-                # for some realistic concerns, we reset the range for
-                # s4: [1MB - 280MB] to avoid failures and missing good broadcast
-                # s5: [10 - 50] to avoid bad performance within same resource usage
-                if n_p_samples == 32:
-                    p_grids = [
-                        [2],  # s1 default
-                        [2],  # s2 default
-                        [0],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
-                        [1, 4, 14, 28],  # s4: autoBroadcastJoinThreshold
-                        [10, 20, 40, 50],  # s5: 80/160 sql.shuffle.partitions
-                        [2],  # s6 default
-                        [50],  # s7: default
-                        [0, 4],  # s8: spark.sql.files.maxPartitionBytes
-                        [2],  # s9: default
-                    ]
-                elif n_p_samples == 64:
-                    p_grids = [
-                        [2],  # s1 default
-                        [2],  # s2 default
-                        [0],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
-                        [1, 4, 14, 28],  # s4: autoBroadcastJoinThreshold
-                        [10, 20, 40, 50],  # s5: 80/160 sql.shuffle.partitions
-                        [2],  # s6 default
-                        [50],  # s7: default
-                        [0, 1, 2, 4],  # s8: spark.sql.files.maxPartitionBytes
-                        [2],  # s9: default
-                    ]
-                elif n_p_samples == 128:
-                    p_grids = [
-                        [2],  # s1 default
-                        [2],  # s2 default
-                        [0],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
-                        [1, 4, 14, 28],  # s4: autoBroadcastJoinThreshold
-                        [10, 20, 40, 50],  # s5: 80/160 sql.shuffle.partitions
-                        [2],  # s6 default
-                        [50],  # s7: default
-                        [0, 1, 2, 4],  # s8: spark.sql.files.maxPartitionBytes
-                        [1, 2],  # s9 - when s4,s5,s8 are concerned, configure the knob
-                    ]
-                else:
-                    raise Exception(
-                        f"# of theta_p samples {n_p_samples} "
-                        f"is not supported for {sample_mode}!"
-                    )
-
-            elif sample_mode == "grid-adaptive-cut-Cum5P":
-                # the choices of grid based on the selected importance of the knobs
-                # set default to parameters from the low rank to the high rank
-                # that cumulatively sum up to 5% of WMAPE
-                #
-                # k7, k1, k3, k2 (set k2, k4, k6, k5 and k8 to default)
-                # s4, s5, s8, s9, s1 (set s2, s3, s6, s7 to default)
-                if n_c_samples not in [32, 54, 128]:
-                    raise Exception(
-                        f"# of theta_c samples {n_c_samples} "
-                        f"is not supported for {sample_mode}!"
-                    )
-                if n_p_samples not in [32, 64, 81, 128, 243]:
-                    raise Exception(
-                        f"# of theta_p samples {n_p_samples} "
-                        f"is not supported for {sample_mode}!"
-                    )
-                if n_c_samples == 32:
-                    c_grids = [
-                        [1, 5],  # k1
-                        [1, 4],  # k2
-                        [4, 8, 12, 16],  # k3
-                        [2],  # k4 - from best practice
-                        [2],  # k5 - default: 2
-                        [0],  # k6 - set to "0"
-                        [0, 1],  # k7
-                        [60],  # k8 - default: 60
-                    ]
-                elif n_c_samples == 54:  # chosen <- 3-value strateg
-                    c_grids = [
-                        [1, 3, 5],  # k1
-                        [1, 2, 3],  # k2
-                        [4, 10, 16],  # k3 -> Fixme: diff
-                        [2],  # k4 - from best practice
-                        [2],  # k5 - default: 2
-                        [0],  # k6 - set to "0"
-                        [0, 1],  # k7 -> Fixme: diff
-                        [60],  # k8 - default: 60
-                    ]
-                elif n_c_samples == 128:
-                    c_grids = [
-                        [1, 2, 4, 5],  # k1
-                        [1, 2, 3, 4],  # k2
-                        [4, 8, 12, 16],  # k3
-                        [2],  # k4 - from best practice
-                        [2],  # k5 - default: 2
-                        [0],  # k6 - set to "0"
-                        [0, 1],  # k7
-                        [60],  # k8 - default: 60
-                    ]
-                else:
-                    raise Exception(
-                        f"# of theta_c samples {n_c_samples} "
-                        f"is not supported for {sample_mode}!"
-                    )
-
-                # s4, s5, s8, s9, s1 (set s2, s3, s6, s7 to default)
-                # for some realistic concerns, we reset the range for
-                # s4: [0MB - 280MB] to avoid failures and missing good broadcast
-                # s5: [10 - 50] to avoid bad performance within same resource usage
-                if n_p_samples == 32:
-                    p_grids = [
-                        [0, 5],  # s1
-                        [2],  # s2 default
-                        [0],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
-                        [1, 28],  # s4: 10MB/280MB autoBroadcastJoinThreshold
-                        [10, 50],  # s5: 80/400 sql.shuffle.partitions
-                        [2],  # s6 default
-                        [50],  # s7: default
-                        [0, 4],  # s8: spark.sql.files.maxPartitionBytes
-                        [0, 4],  # s9: default
-                    ]
-                elif n_p_samples == 64:
-                    p_grids = [
-                        [0, 5],  # s1
-                        [2],  # s2 default
-                        [0],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
-                        [1, 4, 14, 28],  # s4: 10MB/280MB autoBroadcastJoinThreshold
-                        [10, 50],  # s5: 80/400 sql.shuffle.partitions
-                        [2],  # s6 default
-                        [50],  # s7: default
-                        [0, 4],  # s8: spark.sql.files.maxPartitionBytes
-                        [0, 4],  # s9: default
-                    ]
-                elif n_p_samples == 81:  # 3^4 = 81
-                    p_grids = [
-                        [2],  # s1 <--
-                        [2],  # s2 default
-                        [0],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
-                        [0, 14, 28],  # s4: 10MB/280MB autoBroadcastJoinThreshold
-                        [10, 20, 50],  # s5: 80/400 sql.shuffle.partitions
-                        [2],  # s6 default
-                        [50],  # s7: default
-                        [
-                            0,
-                            2,
-                            4,
-                        ],  # s8: spark.sql.files.maxPartitionBytes <-- fixme: diff
-                        [0, 2, 4],  # s9: default <-- fixme: diff
-                    ]
-                elif n_p_samples == 243:  # 3^5 = 243
-                    p_grids = [
-                        [0, 2, 5],  # s1 <--
-                        [2],  # s2 default
-                        [0],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
-                        [0, 14, 28],  # s4: 10MB/280MB autoBroadcastJoinThreshold
-                        [10, 20, 50],  # s5: 80/400 sql.shuffle.partitions
-                        [2],  # s6 default
-                        [50],  # s7: default
-                        [0, 2, 4],  # s8: spark.sql.files.maxPartitionBytes
-                        [0, 2, 4],  # s9: default <--
-                    ]
-                elif n_p_samples == 128:  #
-                    p_grids = [
-                        [0, 5],  # s1
-                        [2],  # s2 default
-                        [0],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
-                        [1, 4, 14, 28],  # s4: 10MB/280MB autoBroadcastJoinThreshold
-                        [10, 20, 40, 50],  # s5: 80/400 sql.shuffle.partitions
-                        [2],  # s6 default
-                        [50],  # s7: default
-                        [0, 4],  # s8: spark.sql.files.maxPartitionBytes
-                        [0, 4],  # s9: default
-                    ]
-                else:
-                    raise Exception(
-                        f"# of theta_p samples {n_p_samples} "
-                        f"is not supported for {sample_mode}!"
-                    )
-            elif sample_mode == "grid-adaptive-cut-Cum5P-2":
-                # s8: [0, 2, 4] -> [1, 2, 3]
-
-                # the choices of grid based on the selected importance of the knobs
-                # set default to parameters from the low rank to the high rank
-                # that cumulatively sum up to 5% of WMAPE
-                #
-                # k7, k1, k3, k2 (set k2, k4, k6, k5 and k8 to default)
-                # s4, s5, s8, s9, s1 (set s2, s3, s6, s7 to default)
-                if n_c_samples not in [54]:
-                    raise Exception(
-                        f"# of theta_c samples {n_c_samples} "
-                        f"is not supported for {sample_mode}!"
-                    )
-                if n_p_samples not in [81]:
-                    raise Exception(
-                        f"# of theta_p samples {n_p_samples} "
-                        f"is not supported for {sample_mode}!"
-                    )
-                if n_c_samples == 54:  # chosen <- 3-value strateg
-                    c_grids = [
-                        [1, 3, 5],  # k1
-                        [1, 2, 3],  # k2
-                        [4, 10, 16],  # k3 -> Fixme: diff
-                        [2],  # k4 - from best practice
-                        [2],  # k5 - default: 2
-                        [0],  # k6 - set to "0"
-                        [0, 1],  # k7 -> Fixme: diff
-                        [60],  # k8 - default: 60
-                    ]
-                else:
-                    raise Exception(
-                        f"# of theta_c samples {n_c_samples} "
-                        f"is not supported for {sample_mode}!"
-                    )
-
-                # s4, s5, s8, s9, s1 (set s2, s3, s6, s7 to default)
-                # for some realistic concerns, we reset the range for
-                # s4: [0MB - 280MB] to avoid failures and missing good broadcast
-                # s5: [10 - 50] to avoid bad performance within same resource usage
-                if n_p_samples == 81:  # 3^4 = 81
-                    p_grids = [
-                        [2],  # s1 <--
-                        [2],  # s2 default
-                        [0],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
-                        [0, 14, 28],  # s4: 10MB/280MB autoBroadcastJoinThreshold
-                        [10, 20, 50],  # s5: 80/400 sql.shuffle.partitions
-                        [2],  # s6 default
-                        [50],  # s7: default
-                        [
-                            1,
-                            2,
-                            3,
-                        ],  # s8: spark.sql.files.maxPartitionBytes <-- fixme: diff
-                        [0, 2, 4],  # s9: default <-- fixme: diff
-                    ]
-                else:
-                    raise Exception(
-                        f"# of theta_p samples {n_p_samples} "
-                        f"is not supported for {sample_mode}!"
-                    )
-            elif sample_mode == "grid-adaptive-cut-Cum5P-3":
-                # k3: [4, 10, 16] -> [8, 12, 16]
-
-                # the choices of grid based on the selected importance of the knobs
-                # set default to parameters from the low rank to the high rank
-                # that cumulatively sum up to 5% of WMAPE
-                #
-                # k7, k1, k3, k2 (set k2, k4, k6, k5 and k8 to default)
-                # s4, s5, s8, s9, s1 (set s2, s3, s6, s7 to default)
-                if n_c_samples not in [54]:
-                    raise Exception(
-                        f"# of theta_c samples {n_c_samples} "
-                        f"is not supported for {sample_mode}!"
-                    )
-                if n_p_samples not in [81, 243]:
-                    raise Exception(
-                        f"# of theta_p samples {n_p_samples} "
-                        f"is not supported for {sample_mode}!"
-                    )
-                if n_c_samples == 54:  # chosen <- 3-value strateg
-                    c_grids = [
-                        [1, 3, 5],  # k1
-                        [1, 2, 3],  # k2
-                        [8, 12, 16],  # k3 -> Fixme: diff
-                        [2],  # k4 - from best practice
-                        [2],  # k5 - default: 2
-                        [0],  # k6 - set to "0"
-                        [0, 1],  # k7 -> Fixme: diff
-                        [60],  # k8 - default: 60
-                    ]
-                else:
-                    raise Exception(
-                        f"# of theta_c samples {n_c_samples} "
-                        f"is not supported for {sample_mode}!"
-                    )
-
-                # s4, s5, s8, s9, s1 (set s2, s3, s6, s7 to default)
-                # for some realistic concerns, we reset the range for
-                # s4: [0MB - 280MB] to avoid failures and missing good broadcast
-                # s5: [10 - 50] to avoid bad performance within same resource usage
-                if n_p_samples == 81:  # 3^4 = 81
-                    p_grids = [
-                        [2],  # s1 <--
-                        [2],  # s2 default
-                        [0],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
-                        [0, 14, 28],  # s4: 10MB/280MB autoBroadcastJoinThreshold
-                        [10, 20, 50],  # s5: 80/400 sql.shuffle.partitions
-                        [2],  # s6 default
-                        [50],  # s7: default
-                        [0, 2, 4],  # s8: spark.sql.files.maxPartitionBytes
-                        [0, 2, 4],  # s9: default <-- fixme: diff
-                    ]
-                if n_p_samples == 243:  # 3^5 = 81
-                    p_grids = [
-                        [2],  # s1 <--
-                        [2],  # s2 default
-                        [
-                            0,
-                            14,
-                            28,
-                        ],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
-                        [0, 14, 28],  # s4: 10MB/280MB autoBroadcastJoinThreshold
-                        [10, 20, 50],  # s5: 80/400 sql.shuffle.partitions
-                        [2],  # s6 default
-                        [50],  # s7: default
-                        [0, 2, 4],  # s8: spark.sql.files.maxPartitionBytes
-                        [0, 2, 4],  # s9: default <-- fixme: diff
-                    ]
-                else:
-                    raise Exception(
-                        f"# of theta_p samples {n_p_samples} "
-                        f"is not supported for {sample_mode}!"
-                    )
-            elif sample_mode == "grid-adaptive-cut-Cum5P-4":
-                # k3=[4, 10, 16] & turn on s3 in 81
-
-                # the choices of grid based on the selected importance of the knobs
-                # set default to parameters from the low rank to the high rank
-                # that cumulatively sum up to 5% of WMAPE
-                #
-                # k7, k1, k3, k2 (set k2, k4, k6, k5 and k8 to default)
-                # s4, s5, s8, s9, s1 (set s2, s3, s6, s7 to default)
-                if n_c_samples not in [54]:
-                    raise Exception(
-                        f"# of theta_c samples {n_c_samples} "
-                        f"is not supported for {sample_mode}!"
-                    )
-                if n_p_samples not in [81]:
-                    raise Exception(
-                        f"# of theta_p samples {n_p_samples} "
-                        f"is not supported for {sample_mode}!"
-                    )
-                if n_c_samples == 54:  # chosen <- 3-value strateg
-                    c_grids = [
-                        [1, 3, 5],  # k1
-                        [1, 2, 3],  # k2
-                        [4, 10, 16],  # k3 -> Fixme: diff
-                        [2],  # k4 - from best practice
-                        [2],  # k5 - default: 2
-                        [0],  # k6 - set to "0"
-                        [0, 1],  # k7 -> Fixme: diff
-                        [60],  # k8 - default: 60
-                    ]
-                else:
-                    raise Exception(
-                        f"# of theta_c samples {n_c_samples} "
-                        f"is not supported for {sample_mode}!"
-                    )
-
-                # s4, s5, s8, s9, s1 (set s2, s3, s6, s7 to default)
-                # for some realistic concerns, we reset the range for
-                # s4: [0MB - 280MB] to avoid failures and missing good broadcast
-                # s5: [10 - 50] to avoid bad performance within same resource usage
-                if n_p_samples == 81:  # 3^4 = 81
-                    p_grids = [
-                        [2],  # s1 <--
-                        [2],  # s2 default
-                        [
-                            0,
-                            14,
-                            28,
-                        ],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
-                        [0, 14, 28],  # s4: 10MB/280MB autoBroadcastJoinThreshold
-                        [10, 20, 50],  # s5: 80/400 sql.shuffle.partitions
-                        [2],  # s6 default
-                        [50],  # s7: default
-                        [0, 2, 4],  # s8: spark.sql.files.maxPartitionBytes
-                        [2],  # s9: default <-- fixme: diff
-                    ]
-                else:
-                    raise Exception(
-                        f"# of theta_p samples {n_p_samples} "
-                        f"is not supported for {sample_mode}!"
-                    )
-
-            elif sample_mode == "grid-adaptive-cut-Cum5P-5":
+            elif sample_mode == "grid-adaptive-cut":  # cut at cumulative 5\%
                 # k3=[8, 12, 16] & turn on s3 in 81
 
                 # the choices of grid based on the selected importance of the knobs
@@ -2011,7 +1477,7 @@ class HierarchicalOptimizer(BaseOptimizer):
                 #
                 # k7, k1, k3, k2 (set k2, k4, k6, k5 and k8 to default)
                 # s4, s5, s8, s9, s1 (set s2, s3, s6, s7 to default)
-                if n_c_samples not in [54]:
+                if n_c_samples not in [54, 152]:
                     raise Exception(
                         f"# of theta_c samples {n_c_samples} "
                         f"is not supported for {sample_mode}!"
@@ -2021,15 +1487,37 @@ class HierarchicalOptimizer(BaseOptimizer):
                         f"# of theta_p samples {n_p_samples} "
                         f"is not supported for {sample_mode}!"
                     )
-                if n_c_samples == 54:  # chosen <- 3-value strateg
+                if n_c_samples == 54:
                     c_grids = [
                         [1, 3, 5],  # k1
                         [1, 2, 3],  # k2
-                        [8, 12, 16],  # k3 -> Fixme: diff
+                        [8, 12, 16],  # k3
                         [2],  # k4 - from best practice
                         [2],  # k5 - default: 2
                         [0],  # k6 - set to "0"
-                        [0, 1],  # k7 -> Fixme: diff
+                        [0, 1],  # k7
+                        [60],  # k8 - default: 60
+                    ]
+                elif n_c_samples == 90:  # 5 * 3 * 3 * 2 = 90
+                    c_grids = [
+                        [1, 2, 3, 4, 5],  # k1
+                        [1, 2, 3],  # k2
+                        [8, 12, 16],  # k3
+                        [2],  # k4 - from best practice
+                        [2],  # k5 - default: 2
+                        [0],  # k6 - set to "0"
+                        [0, 1],  # k7
+                        [60],  # k8 - default: 60
+                    ]
+                elif n_c_samples == 150:  # 5 * 5 * 3 * 2 = 150
+                    c_grids = [
+                        [1, 2, 3, 4, 5],  # k1
+                        [1, 2, 3],  # k2
+                        [8, 10, 12, 14, 16],  # k3
+                        [2],  # k4 - from best practice
+                        [2],  # k5 - default: 2
+                        [0],  # k6 - set to "0"
+                        [0, 1],  # k7
                         [60],  # k8 - default: 60
                     ]
                 else:
@@ -2046,17 +1534,13 @@ class HierarchicalOptimizer(BaseOptimizer):
                     p_grids = [
                         [2],  # s1 <--
                         [2],  # s2 default
-                        [
-                            0,
-                            14,
-                            28,
-                        ],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
-                        [0, 14, 28],  # s4: 10MB/280MB autoBroadcastJoinThreshold
-                        [10, 20, 50],  # s5: 80/400 sql.shuffle.partitions
+                        [0, 14, 28],  # s3: maxShuffledHashJoinLocalMapThreshold
+                        [0, 14, 28],  # s4: 10/140/280MB autoBroadcastJoinThreshold
+                        [10, 20, 50],  # s5: 80/160/400 sql.shuffle.partitions
                         [2],  # s6 default
                         [50],  # s7: default
                         [0, 2, 4],  # s8: spark.sql.files.maxPartitionBytes
-                        [2],  # s9: default <-- fixme: diff
+                        [2],  # s9: default
                     ]
                 else:
                     raise Exception(

--- a/udao_spark/optimizer/hierarchical_optimizer.py
+++ b/udao_spark/optimizer/hierarchical_optimizer.py
@@ -1865,6 +1865,62 @@ class HierarchicalOptimizer(BaseOptimizer):
                         f"# of theta_p samples {n_p_samples} "
                         f"is not supported for {sample_mode}!"
                     )
+            elif sample_mode == "grid-adaptive-cut-Cum5P-3":
+                # the choices of grid based on the selected importance of the knobs
+                # set default to parameters from the low rank to the high rank
+                # that cumulatively sum up to 5% of WMAPE
+                #
+                # k7, k1, k3, k2 (set k2, k4, k6, k5 and k8 to default)
+                # s4, s5, s8, s9, s1 (set s2, s3, s6, s7 to default)
+                if n_c_samples not in [54]:
+                    raise Exception(
+                        f"# of theta_c samples {n_c_samples} "
+                        f"is not supported for {sample_mode}!"
+                    )
+                if n_p_samples not in [81]:
+                    raise Exception(
+                        f"# of theta_p samples {n_p_samples} "
+                        f"is not supported for {sample_mode}!"
+                    )
+                if n_c_samples == 54:  # chosen <- 3-value strateg
+                    c_grids = [
+                        [1, 3, 5],  # k1
+                        [1, 2, 3],  # k2
+                        [8, 12, 16],  # k3 -> Fixme: diff
+                        [2],  # k4 - from best practice
+                        [2],  # k5 - default: 2
+                        [0],  # k6 - set to "0"
+                        [0, 1],  # k7 -> Fixme: diff
+                        [60],  # k8 - default: 60
+                    ]
+                else:
+                    raise Exception(
+                        f"# of theta_c samples {n_c_samples} "
+                        f"is not supported for {sample_mode}!"
+                    )
+
+                # s4, s5, s8, s9, s1 (set s2, s3, s6, s7 to default)
+                # for some realistic concerns, we reset the range for
+                # s4: [0MB - 280MB] to avoid failures and missing good broadcast
+                # s5: [10 - 50] to avoid bad performance within same resource usage
+                if n_p_samples == 81:  # 3^4 = 81
+                    p_grids = [
+                        [2],  # s1 <--
+                        [2],  # s2 default
+                        [0],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
+                        [0, 14, 28],  # s4: 10MB/280MB autoBroadcastJoinThreshold
+                        [10, 20, 50],  # s5: 80/400 sql.shuffle.partitions
+                        [2],  # s6 default
+                        [50],  # s7: default
+                        [0, 2, 4],  # s8: spark.sql.files.maxPartitionBytes
+                        [0, 2, 4],  # s9: default <-- fixme: diff
+                    ]
+                else:
+                    raise Exception(
+                        f"# of theta_p samples {n_p_samples} "
+                        f"is not supported for {sample_mode}!"
+                    )
+
             else:
                 raise Exception(
                     f"The sample mode {sample_mode} for theta is not supported!"

--- a/udao_spark/optimizer/hierarchical_optimizer.py
+++ b/udao_spark/optimizer/hierarchical_optimizer.py
@@ -127,10 +127,8 @@ class HierarchicalOptimizer(BaseOptimizer):
         save_data_header: str = "./output",
         is_query_control: bool = False,
         benchmark: str = "tpch",
-        weights: np.ndarray = np.array([0.9, 0.1]),
         selected_features: Optional[Dict[str, List[str]]] = None,
-        return_pareto_set: bool = False,
-    ) -> Tuple[Optional[np.ndarray], Optional[np.ndarray]]:
+    ) -> Tuple[Optional[np.ndarray], Optional[np.ndarray], float]:
         self.current_target_template = template
 
         # initial a monitor
@@ -195,9 +193,7 @@ class HierarchicalOptimizer(BaseOptimizer):
                 save_data_header,
                 benchmark=benchmark,
                 join_ids=join_ids,
-                weights=weights,
                 selected_features=selected_features,
-                return_pareto_set=return_pareto_set,
             )
 
         elif algo == "evo":
@@ -300,7 +296,7 @@ class HierarchicalOptimizer(BaseOptimizer):
 
         logger.info(f"conf: {conf}")
         logger.info(f"objs: {objs}")
-        return objs, conf
+        return objs, conf, tc_end_to_end
 
     def _hmooc(
         self,
@@ -322,10 +318,9 @@ class HierarchicalOptimizer(BaseOptimizer):
         save_data_header: str,
         benchmark: str,
         join_ids: List[int],
-        weights: np.ndarray = np.array([1.0, 1.0]),
         selected_features: Optional[Dict[str, List[str]]] = None,
-        return_pareto_set: bool = False,  # return PO set or WUN point
     ) -> Tuple[Optional[np.ndarray], Optional[np.ndarray]]:
+        # return the pareto set
         start = time.time()
         theta_c: Union[th.Tensor, np.ndarray]
         theta_p: Union[th.Tensor, np.ndarray]
@@ -544,10 +539,8 @@ class HierarchicalOptimizer(BaseOptimizer):
                     f"query_{query_id}_n_{n_subQs}/{sample_mode}/{dag_opt_algo}"
                 )
 
-        # add WUN
-        ret_objs, ret_conf = weighted_utopia_nearest(
-            po_objs, np.array(po_conf_agg_list), weights
-        )
+        # placeholder to compute WUN time.
+        weighted_utopia_nearest(po_objs, np.array(po_conf_agg_list))
         tc_po_rec = time.time() - start_rec
         print(f"FUNCTION: time cost of {algo} with WUN " f"is: {tc_po_rec}")
 
@@ -571,13 +564,10 @@ class HierarchicalOptimizer(BaseOptimizer):
                 pref2theta_agg, f"{data_path}/pref2theta_agg.json", 2
             )
 
-        if return_pareto_set:
-            return (
-                po_objs,
-                np.array(po_conf_agg_list),
-            )
-        else:
-            return ret_objs, ret_conf
+        return (
+            po_objs,
+            np.array(po_conf_agg_list),
+        )
 
     def _evo(
         self,
@@ -1188,103 +1178,134 @@ class HierarchicalOptimizer(BaseOptimizer):
             else:
                 theta_c = th.tensor(theta_c_samples, dtype=th.float32)
                 theta_p = th.tensor(theta_p_samples, dtype=th.float32)
-        elif sample_mode == "grid-search":
-            if n_c_samples == 256:
-                c_grids = [
-                    [1, 5],
-                    [1, 4],
-                    [4, 16],
-                    [1, 4],
-                    [0, 5],
-                    [0, 1],
-                    [0, 1],
-                    [50, 75],
-                ]
-            elif n_c_samples == 128:
-                c_grids = [
-                    [1, 5],
-                    [1, 4],
-                    [4, 16],
-                    [1, 4],
-                    [0, 5],
-                    [0, 1],
-                    [1],
-                    [50, 75],
-                ]
-
-            elif n_c_samples == 160:  # 4  2  5  1  2 * 2 = 160
-                c_grids = [
-                    [1, 2, 3, 5],  # 4
-                    [1, 2],  # 2
-                    [8, 10, 12, 14, 16],  # 5
-                    [2],
-                    [2],
-                    [0, 1],  # 2
-                    [1],
-                    [50, 75],  # 2
-                ]
-
-            elif n_c_samples == 360:  # 4  2  5  1  2 * 2 = 360
-                c_grids = [
-                    [1, 2, 3, 4, 5],  # 5
-                    [1, 2, 3],  # 3
-                    [6, 8, 10, 12, 14, 16],  # 6
-                    [2],
-                    [2],
-                    [0, 1],  # 2
-                    [1],
-                    [50, 75],  # 2
-                ]
-
-            elif n_c_samples == 64:
-                if "test_end" in save_data_header:
-                    # to test for end-to-end
+        elif sample_mode.startswith("grid"):
+            if sample_mode == "grid-search":
+                if n_c_samples == 512:
                     c_grids = [
-                        [2, 3, 4, 5],
-                        [1, 2, 3, 4],
-                        [4, 8, 12, 16],
+                        [1, 2, 4, 5],
                         [1, 4],
-                        [0, 5],
-                        [0],
-                        [1],
-                        [50, 75],
+                        [4, 16],
+                        [1, 4],
+                        [0, 5],  # k5 not important
+                        [0, 1],
+                        [0, 1],
+                        [60],  # k8 not important
                     ]
-                else:
+
+                elif n_c_samples == 256:
                     c_grids = [
                         [1, 5],
                         [1, 4],
                         [4, 16],
                         [1, 4],
                         [0, 5],
-                        [0],
-                        [1],
+                        [0, 1],
+                        [0, 1],
                         [50, 75],
                     ]
-            elif n_c_samples == 36:  # 3  2  3 * 2 (<= 64)
-                c_grids = [
-                    [1, 3, 5],  # 3
-                    [1, 2],  # 2
-                    [8, 12, 16],  # 3
-                    [2],
-                    [2],
-                    [0, 1],  # 2
-                    [1],
-                    [60],  # 1
-                ]
-            elif n_c_samples == 32:
-                if "test_end" in save_data_header:
-                    # to test for end-to-end
+                elif n_c_samples == 128:
                     c_grids = [
-                        [2, 3, 4, 5],
-                        [1, 2, 3, 4],
-                        [4, 8, 12, 16],
+                        [1, 5],
                         [1, 4],
-                        [5],
-                        [0],
+                        [4, 16],
+                        [1, 4],
+                        [0, 5],
+                        [0, 1],
                         [1],
                         [50, 75],
                     ]
-                else:
+
+                elif n_c_samples == 160:  # 4  2  5  1  2 * 2 = 160
+                    # e2e performance and time measurements
+                    # 32 - choose top-5 with all high-low combinations
+                    # 2^6 64 (all high-low combinations)
+                    # 2^7 128 (4 for most important knob k3)
+                    # 2^8 256 (4 for top-2 most important knob k3, k1)
+
+                    c_grids = [
+                        [1, 2, 3, 5],  # 4
+                        [1, 2],  # 2
+                        [8, 10, 12, 14, 16],  # 5
+                        [2],  # k4
+                        [2],
+                        [0, 1],  # 2
+                        [1],  # need more choices for k7
+                        [60],  # 2
+                    ]
+
+                elif n_c_samples == 360:  # 4  2  5  1  2 * 2 = 360
+                    c_grids = [
+                        [1, 2, 3, 4, 5],  # 5
+                        [1, 2, 3],  # 3
+                        [6, 8, 10, 12, 14, 16],  # 6
+                        [2],
+                        [2],
+                        [0, 1],  # 2
+                        [1],
+                        [50, 75],  # 2
+                    ]
+
+                elif n_c_samples == 64:
+                    if "test_end" in save_data_header:
+                        # to test for end-to-end
+                        c_grids = [
+                            [2, 3, 4, 5],
+                            [1, 2, 3, 4],
+                            [4, 8, 12, 16],
+                            [1, 4],
+                            [0, 5],
+                            [0],
+                            [1],
+                            [50, 75],
+                        ]
+                    else:
+                        c_grids = [
+                            [1, 5],
+                            [1, 4],
+                            [4, 16],
+                            [1, 4],
+                            [0, 5],
+                            [0],
+                            [1],
+                            [50, 75],
+                        ]
+                elif n_c_samples == 36:  # 3  2  3 * 2 (<= 64)
+                    c_grids = [
+                        [1, 3, 5],  # 3
+                        [1, 2],  # 2
+                        [8, 12, 16],  # 3
+                        [2],
+                        [2],
+                        [0, 1],  # 2
+                        [1],
+                        [60],  # 1
+                    ]
+                elif n_c_samples == 32:
+                    if "test_end" in save_data_header:
+                        # to test for end-to-end
+                        c_grids = [
+                            [2, 3, 4, 5],
+                            [1, 2, 3, 4],
+                            [4, 8, 12, 16],
+                            [1, 4],
+                            [5],
+                            [0],
+                            [1],
+                            [50, 75],
+                        ]
+                    else:
+                        c_grids = [
+                            [1, 5],
+                            [1, 4],
+                            [4, 16],
+                            [1, 4],
+                            [5],
+                            [0],
+                            [1],
+                            [50, 75],
+                        ]
+
+                elif n_c_samples == 16:
                     c_grids = [
                         [1, 5],
                         [1, 4],
@@ -1293,50 +1314,25 @@ class HierarchicalOptimizer(BaseOptimizer):
                         [5],
                         [0],
                         [1],
-                        [50, 75],
+                        [50],
                     ]
+                elif n_c_samples == 1:
+                    c_grids = [
+                        [1],  # r1: 1, r2: 3, r3: 5, r4: 1
+                        [1],  # r1: 1, r2: 1, r3: 4, r4: 4
+                        [16],  # r1: 4, r2: 16, r3: 16, r4: 4
+                        [1],
+                        [5],
+                        [0],
+                        [1],
+                        [75],  ##1,1,16
+                    ]
+                else:
+                    raise Exception(f"n_c_samples {n_c_samples} is not supported!")
 
-            elif n_c_samples == 16:
-                c_grids = [
-                    [1, 5],
-                    [1, 4],
-                    [4, 16],
-                    [1, 4],
-                    [5],
-                    [0],
-                    [1],
-                    [50],
-                ]
-            elif n_c_samples == 1:
-                c_grids = [
-                    [1],  # r1: 1, r2: 3, r3: 5, r4: 1
-                    [1],  # r1: 1, r2: 1, r3: 4, r4: 4
-                    [16],  # r1: 4, r2: 16, r3: 16, r4: 4
-                    [1],
-                    [5],
-                    [0],
-                    [1],
-                    [75],  ##1,1,16
-                ]
-            else:
-                raise Exception(f"n_c_samples {n_c_samples} is not supported!")
-
-            if n_p_samples == 512:
-                p_grids = [
-                    [0, 5],
-                    [1, 6],
-                    [0, 32],
-                    [0, 32],
-                    [2, 50],
-                    [0, 4],
-                    [20, 80],
-                    [0, 4],
-                    [0, 4],
-                ]
-            elif n_p_samples == 256:
-                if "test_end_diff_p" in save_data_header:
+                if n_p_samples == 512:
                     p_grids = [
-                        [0],
+                        [0, 5],
                         [1, 6],
                         [0, 32],
                         [0, 32],
@@ -1346,7 +1342,58 @@ class HierarchicalOptimizer(BaseOptimizer):
                         [0, 4],
                         [0, 4],
                     ]
-                else:
+                elif n_p_samples == 256:
+                    if "test_end_diff_p" in save_data_header:
+                        p_grids = [
+                            [0],
+                            [1, 6],
+                            [0, 32],
+                            [0, 32],
+                            [2, 50],
+                            [0, 4],
+                            [20, 80],
+                            [0, 4],
+                            [0, 4],
+                        ]
+                    else:
+                        p_grids = [
+                            [0],
+                            [1, 6],
+                            [0, 32],
+                            [0, 32],
+                            [2, 50],
+                            [0, 4],
+                            [20, 80],
+                            [0, 4],
+                            [0, 4],
+                        ]
+                elif n_p_samples == 162:  # 3  3  3  3  2 = 162
+                    p_grids = [
+                        [2],  # default
+                        [2],  # default
+                        [0, 14, 28],  # 0MB/160MB maxShuffledHashJoinLocalMapThreshold
+                        [0, 14, 28],  # 0MB/160MB autoBroadcastJoinThreshold
+                        [10, 20, 40],  # 80/160/320 sql.shuffle.partitions
+                        [2],
+                        [50],  # default
+                        [1, 2, 3],
+                        [1, 2],  # default
+                    ]
+
+                elif n_p_samples == 324:  # 2 3  3  3  3  2 = 162
+                    p_grids = [
+                        [2, 4],  # default
+                        [2],  # default
+                        [0, 14, 28],  # 0MB/160MB maxShuffledHashJoinLocalMapThreshold
+                        [0, 14, 28],  # 0MB/160MB autoBroadcastJoinThreshold
+                        [10, 20, 40],  # 80/160/320 sql.shuffle.partitions
+                        [2],
+                        [50],  # default
+                        [1, 2, 3],
+                        [1, 2],  # default
+                    ]
+
+                elif n_p_samples == 128:
                     p_grids = [
                         [0],
                         [1, 6],
@@ -1355,61 +1402,59 @@ class HierarchicalOptimizer(BaseOptimizer):
                         [2, 50],
                         [0, 4],
                         [20, 80],
-                        [0, 4],
+                        [0],
                         [0, 4],
                     ]
-            elif n_p_samples == 162:  # 3  3  3  3  2 = 162
-                p_grids = [
-                    [2],  # default
-                    [2],  # default
-                    [0, 14, 28],  # 0MB/160MB maxShuffledHashJoinLocalMapThreshold
-                    [0, 14, 28],  # 0MB/160MB autoBroadcastJoinThreshold
-                    [10, 20, 40],  # 80/160/320 sql.shuffle.partitions
-                    [2],
-                    [50],  # default
-                    [1, 2, 3],
-                    [1, 2],  # default
-                ]
-
-            elif n_p_samples == 324:  # 2 3  3  3  3  2 = 162
-                p_grids = [
-                    [2, 4],  # default
-                    [2],  # default
-                    [0, 14, 28],  # 0MB/160MB maxShuffledHashJoinLocalMapThreshold
-                    [0, 14, 28],  # 0MB/160MB autoBroadcastJoinThreshold
-                    [10, 20, 40],  # 80/160/320 sql.shuffle.partitions
-                    [2],
-                    [50],  # default
-                    [1, 2, 3],
-                    [1, 2],  # default
-                ]
-
-            elif n_p_samples == 128:
-                p_grids = [
-                    [0],
-                    [1, 6],
-                    [0, 32],
-                    [0, 32],
-                    [2, 50],
-                    [0, 4],
-                    [20, 80],
-                    [0],
-                    [0, 4],
-                ]
-            elif n_p_samples == 64:
-                p_grids = [
-                    [0],
-                    [1],
-                    [0, 32],
-                    [0, 32],
-                    [2, 50],
-                    [0, 4],
-                    [20, 80],
-                    [0],
-                    [0, 4],
-                ]
-            elif n_p_samples == 32:
-                if "test_end_diff_p" in save_data_header:
+                elif n_p_samples == 64:
+                    p_grids = [
+                        [0],
+                        [1],
+                        [0, 32],
+                        [0, 32],
+                        [2, 50],
+                        [0, 4],
+                        [20, 80],
+                        [0],
+                        [0, 4],
+                    ]
+                elif n_p_samples == 32:
+                    if "test_end_diff_p" in save_data_header:
+                        p_grids = [
+                            [0],
+                            [1],
+                            [0, 32],
+                            [0, 32],
+                            [2, 50],
+                            [0],
+                            [20, 80],
+                            [0],
+                            [0, 4],
+                        ]
+                    else:
+                        p_grids = [
+                            [0],
+                            [1],
+                            [0, 32],
+                            [0, 32],
+                            [2, 50],
+                            [0],
+                            [20, 80],
+                            [0],
+                            [0, 4],
+                        ]
+                elif n_p_samples == 24:  # 2  2  2 * 3
+                    p_grids = [
+                        [2],  # default
+                        [2],  # default
+                        [0, 14],  # 0MB/140MB maxShuffledHashJoinLocalMapThreshold
+                        [0, 14],  # 0MB/140MB autoBroadcastJoinThreshold
+                        [10, 20],  # 80/160 sql.shuffle.partitions
+                        [2],
+                        [50],  # default
+                        [1, 2, 3],
+                        [2],  # default
+                    ]
+                elif n_p_samples == 16:
                     p_grids = [
                         [0],
                         [1],
@@ -1419,46 +1464,211 @@ class HierarchicalOptimizer(BaseOptimizer):
                         [0],
                         [20, 80],
                         [0],
-                        [0, 4],
+                        [0],
                     ]
                 else:
-                    p_grids = [
-                        [0],
-                        [1],
-                        [0, 32],
-                        [0, 32],
-                        [2, 50],
-                        [0],
-                        [20, 80],
-                        [0],
-                        [0, 4],
+                    raise Exception(f"n_p_samples {n_p_samples} is not supported!")
+
+            elif sample_mode == "grid-adaptive-cut-1P":
+                # the choices of grid based on the selected importance of the knobs
+                # k7, k1, k3, k2, k4, k6 (set k5 and k8 to default)
+                # s4, s5, s8, s9, s1 (set s2, s3, s6, s7 to default)
+                if n_c_samples not in [32, 64, 128, 256]:
+                    raise Exception(
+                        f"# of theta_c samples {n_c_samples} "
+                        f"is not supported for {sample_mode}!"
+                    )
+                if n_p_samples not in [32, 64, 128]:
+                    raise Exception(
+                        f"# of theta_p samples {n_p_samples} "
+                        f"is not supported for {sample_mode}!"
+                    )
+                if n_c_samples == 32:
+                    c_grids = [
+                        [1, 5],  # k1
+                        [1, 4],  # k2
+                        [4, 16],  # k3
+                        [1, 4],  # k4
+                        [2],  # k5 - default: 2
+                        [0],  # k6 - set to "0"
+                        [0, 1],  # k7
+                        [60],  # k8 - default: 60
                     ]
-            elif n_p_samples == 24:  # 2  2  2 * 3
-                p_grids = [
-                    [2],  # default
-                    [2],  # default
-                    [0, 14],  # 0MB/140MB maxShuffledHashJoinLocalMapThreshold
-                    [0, 14],  # 0MB/140MB autoBroadcastJoinThreshold
-                    [10, 20],  # 80/160 sql.shuffle.partitions
-                    [2],
-                    [50],  # default
-                    [1, 2, 3],
-                    [2],  # default
-                ]
-            elif n_p_samples == 16:
-                p_grids = [
-                    [0],
-                    [1],
-                    [0, 32],
-                    [0, 32],
-                    [2, 50],
-                    [0],
-                    [20, 80],
-                    [0],
-                    [0],
-                ]
+                elif n_c_samples == 64:
+                    c_grids = [
+                        [1, 5],  # k1
+                        [1, 4],  # k2
+                        [4, 16],  # k3
+                        [1, 4],  # k4
+                        [2],  # k5 - default: 2
+                        [0, 1],  # k6
+                        [0, 1],  # k7
+                        [60],  # k8 - default: 60
+                    ]
+                elif n_c_samples == 128:
+                    c_grids = [
+                        [1, 2, 4, 5],  # k1
+                        [1, 4],  # k2
+                        [4, 16],  # k3
+                        [1, 4],  # k4
+                        [2],  # k5 - default: 2
+                        [0, 1],  # k6
+                        [0, 1],  # k7
+                        [60],  # k8 - default: 60
+                    ]
+                elif n_c_samples == 256:
+                    c_grids = [
+                        [1, 2, 4, 5],  # k1
+                        [1, 4],  # k2
+                        [4, 8, 12, 16],  # k3
+                        [1, 4],  # k4
+                        [2],  # k5 - default: 2
+                        [0, 1],  # k6
+                        [0, 1],  # k7
+                        [60],  # k8 - default: 60
+                    ]
+                else:
+                    raise Exception(
+                        f"# of theta_c samples {n_c_samples} "
+                        f"is not supported for {sample_mode}!"
+                    )
+
+                # for some realistic concerns, we reset the range for
+                # s4: [1MB - 280MB] to avoid failures and missing good broadcast
+                # s5: [10 - 50] to avoid bad performance within same resource usage
+                if n_p_samples == 32:
+                    p_grids = [
+                        [0, 5],  # s1
+                        [2],  # s2 default
+                        [0],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
+                        [1, 28],  # s4: 10MB/280MB autoBroadcastJoinThreshold
+                        [10, 50],  # s5: 80/400 sql.shuffle.partitions
+                        [2],  # s6 default
+                        [50],  # s7: default
+                        [0, 4],  # s8: spark.sql.files.maxPartitionBytes
+                        [0, 4],  # s9: default
+                    ]
+                elif n_p_samples == 64:
+                    p_grids = [
+                        [0, 5],  # s1
+                        [2],  # s2 default
+                        [0],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
+                        [1, 4, 14, 28],  # s4: 10MB/280MB autoBroadcastJoinThreshold
+                        [10, 50],  # s5: 80/400 sql.shuffle.partitions
+                        [2],  # s6 default
+                        [50],  # s7: default
+                        [0, 4],  # s8: spark.sql.files.maxPartitionBytes
+                        [0, 4],  # s9: default
+                    ]
+                elif n_p_samples == 128:
+                    p_grids = [
+                        [0, 5],  # s1
+                        [2],  # s2 default
+                        [0],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
+                        [1, 4, 14, 28],  # s4: 10MB/280MB autoBroadcastJoinThreshold
+                        [10, 20, 40, 50],  # s5: 80/400 sql.shuffle.partitions
+                        [2],  # s6 default
+                        [50],  # s7: default
+                        [0, 4],  # s8: spark.sql.files.maxPartitionBytes
+                        [0, 4],  # s9: default
+                    ]
+                else:
+                    raise Exception(
+                        f"# of theta_p samples {n_p_samples} "
+                        f"is not supported for {sample_mode}!"
+                    )
+
+            elif sample_mode == "grid-adaptive-cut-5P":
+                # the choices of grid based on the selected importance of the knobs
+                # k7, k1, k3 (set k2, k4, k6, k5 and k8 to default)
+                # s4, s5, s8 (set s9, s1, s2, s3, s6, s7 to default)
+                if n_c_samples not in [32, 128]:
+                    raise Exception(
+                        f"# of theta_c samples {n_c_samples} "
+                        f"is not supported for {sample_mode}!"
+                    )
+                if n_p_samples not in [32, 64, 128]:
+                    raise Exception(
+                        f"# of theta_p samples {n_p_samples} "
+                        f"is not supported for {sample_mode}!"
+                    )
+                if n_c_samples == 32:
+                    c_grids = [
+                        [1, 2, 4, 5],  # k1
+                        [1],  # k2
+                        [4, 8, 12, 16],  # k3
+                        [2],  # k4 - from best practice
+                        [2],  # k5 - default: 2
+                        [0],  # k6 - set to "0"
+                        [0, 1],  # k7
+                        [60],  # k8 - default: 60
+                    ]
+                elif n_c_samples == 128:
+                    c_grids = [
+                        [1, 2, 4, 5],  # k1
+                        [1, 2, 3, 4],  # k2
+                        [4, 8, 12, 16],  # k3
+                        [2],  # k4 - from best practice
+                        [2],  # k5 - default: 2
+                        [0],  # k6 - set to "0"
+                        [0, 1],  # k7
+                        [60],  # k8 - default: 60
+                    ]
+                else:
+                    raise Exception(
+                        f"# of theta_c samples {n_c_samples} "
+                        f"is not supported for {sample_mode}!"
+                    )
+
+                # for some realistic concerns, we reset the range for
+                # s4: [1MB - 280MB] to avoid failures and missing good broadcast
+                # s5: [10 - 50] to avoid bad performance within same resource usage
+                if n_p_samples == 32:
+                    p_grids = [
+                        [2],  # s1 default
+                        [2],  # s2 default
+                        [0],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
+                        [1, 4, 14, 28],  # s4: autoBroadcastJoinThreshold
+                        [10, 20, 40, 50],  # s5: 80/160 sql.shuffle.partitions
+                        [2],  # s6 default
+                        [50],  # s7: default
+                        [0, 4],  # s8: spark.sql.files.maxPartitionBytes
+                        [2],  # s9: default
+                    ]
+                elif n_p_samples == 64:
+                    p_grids = [
+                        [2],  # s1 default
+                        [2],  # s2 default
+                        [0],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
+                        [1, 4, 14, 28],  # s4: autoBroadcastJoinThreshold
+                        [10, 20, 40, 50],  # s5: 80/160 sql.shuffle.partitions
+                        [2],  # s6 default
+                        [50],  # s7: default
+                        [0, 1, 2, 4],  # s8: spark.sql.files.maxPartitionBytes
+                        [2],  # s9: default
+                    ]
+                elif n_p_samples == 128:
+                    p_grids = [
+                        [2],  # s1 default
+                        [2],  # s2 default
+                        [0],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
+                        [1, 4, 14, 28],  # s4: autoBroadcastJoinThreshold
+                        [10, 20, 40, 50],  # s5: 80/160 sql.shuffle.partitions
+                        [2],  # s6 default
+                        [50],  # s7: default
+                        [0, 1, 2, 4],  # s8: spark.sql.files.maxPartitionBytes
+                        [1, 2],  # s9 - when s4,s5,s8 are concerned, configure the knob
+                    ]
+                else:
+                    raise Exception(
+                        f"# of theta_p samples {n_p_samples} "
+                        f"is not supported for {sample_mode}!"
+                    )
+
             else:
-                raise Exception(f"n_p_samples {n_p_samples} is not supported!")
+                raise Exception(
+                    f"The sample mode {sample_mode} for theta is not supported!"
+                )
 
             if use_ag:
                 theta_c = np.array([list(i) for i in itertools.product(*c_grids)])

--- a/udao_spark/optimizer/hierarchical_optimizer.py
+++ b/udao_spark/optimizer/hierarchical_optimizer.py
@@ -1271,14 +1271,14 @@ class HierarchicalOptimizer(BaseOptimizer):
                         ]
                 elif n_c_samples == 36:  # 3  2  3 * 2 (<= 64)
                     c_grids = [
-                        [1, 3, 5],  # 3
-                        [1, 2],  # 2
-                        [8, 12, 16],  # 3
-                        [2],
-                        [2],
-                        [0, 1],  # 2
-                        [1],
-                        [60],  # 1
+                        [1, 3, 5],  # k1: 3
+                        [1, 2],  # k2: 2
+                        [8, 12, 16],  # k3: 3
+                        [2],  # k4:
+                        [2],  # k5
+                        [0, 1],  # k6: 2
+                        [1],  # k7
+                        [60],  # k8
                     ]
                 elif n_c_samples == 32:
                     if "test_end" in save_data_header:
@@ -1473,7 +1473,8 @@ class HierarchicalOptimizer(BaseOptimizer):
                 # the choices of grid based on the selected importance of the knobs
                 # k7, k1, k3, k2, k4, k6 (set k5 and k8 to default)
                 # s4, s5, s8, s9, s1 (set s2, s3, s6, s7 to default)
-                if n_c_samples not in [32, 64, 128, 256]:
+                # adjust
+                if n_c_samples not in [32, 64, 128, 256, 512]:
                     raise Exception(
                         f"# of theta_c samples {n_c_samples} "
                         f"is not supported for {sample_mode}!"
@@ -1520,6 +1521,17 @@ class HierarchicalOptimizer(BaseOptimizer):
                     c_grids = [
                         [1, 2, 4, 5],  # k1
                         [1, 4],  # k2
+                        [4, 8, 12, 16],  # k3
+                        [1, 4],  # k4
+                        [2],  # k5 - default: 2
+                        [0, 1],  # k6
+                        [0, 1],  # k7
+                        [60],  # k8 - default: 60
+                    ]
+                elif n_c_samples == 512:
+                    c_grids = [
+                        [1, 2, 4, 5],  # k1
+                        [1, 2, 3, 4],  # k2
                         [4, 8, 12, 16],  # k3
                         [1, 4],  # k4
                         [2],  # k5 - default: 2

--- a/udao_spark/optimizer/hierarchical_optimizer.py
+++ b/udao_spark/optimizer/hierarchical_optimizer.py
@@ -1807,6 +1807,8 @@ class HierarchicalOptimizer(BaseOptimizer):
                         f"is not supported for {sample_mode}!"
                     )
             elif sample_mode == "grid-adaptive-cut-Cum5P-2":
+                # s8: [0, 2, 4] -> [1, 2, 3]
+
                 # the choices of grid based on the selected importance of the knobs
                 # set default to parameters from the low rank to the high rank
                 # that cumulatively sum up to 5% of WMAPE
@@ -1866,6 +1868,143 @@ class HierarchicalOptimizer(BaseOptimizer):
                         f"is not supported for {sample_mode}!"
                     )
             elif sample_mode == "grid-adaptive-cut-Cum5P-3":
+                # k3: [4, 10, 16] -> [8, 12, 16]
+
+                # the choices of grid based on the selected importance of the knobs
+                # set default to parameters from the low rank to the high rank
+                # that cumulatively sum up to 5% of WMAPE
+                #
+                # k7, k1, k3, k2 (set k2, k4, k6, k5 and k8 to default)
+                # s4, s5, s8, s9, s1 (set s2, s3, s6, s7 to default)
+                if n_c_samples not in [54]:
+                    raise Exception(
+                        f"# of theta_c samples {n_c_samples} "
+                        f"is not supported for {sample_mode}!"
+                    )
+                if n_p_samples not in [81, 243]:
+                    raise Exception(
+                        f"# of theta_p samples {n_p_samples} "
+                        f"is not supported for {sample_mode}!"
+                    )
+                if n_c_samples == 54:  # chosen <- 3-value strateg
+                    c_grids = [
+                        [1, 3, 5],  # k1
+                        [1, 2, 3],  # k2
+                        [8, 12, 16],  # k3 -> Fixme: diff
+                        [2],  # k4 - from best practice
+                        [2],  # k5 - default: 2
+                        [0],  # k6 - set to "0"
+                        [0, 1],  # k7 -> Fixme: diff
+                        [60],  # k8 - default: 60
+                    ]
+                else:
+                    raise Exception(
+                        f"# of theta_c samples {n_c_samples} "
+                        f"is not supported for {sample_mode}!"
+                    )
+
+                # s4, s5, s8, s9, s1 (set s2, s3, s6, s7 to default)
+                # for some realistic concerns, we reset the range for
+                # s4: [0MB - 280MB] to avoid failures and missing good broadcast
+                # s5: [10 - 50] to avoid bad performance within same resource usage
+                if n_p_samples == 81:  # 3^4 = 81
+                    p_grids = [
+                        [2],  # s1 <--
+                        [2],  # s2 default
+                        [0],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
+                        [0, 14, 28],  # s4: 10MB/280MB autoBroadcastJoinThreshold
+                        [10, 20, 50],  # s5: 80/400 sql.shuffle.partitions
+                        [2],  # s6 default
+                        [50],  # s7: default
+                        [0, 2, 4],  # s8: spark.sql.files.maxPartitionBytes
+                        [0, 2, 4],  # s9: default <-- fixme: diff
+                    ]
+                if n_p_samples == 243:  # 3^5 = 81
+                    p_grids = [
+                        [2],  # s1 <--
+                        [2],  # s2 default
+                        [
+                            0,
+                            14,
+                            28,
+                        ],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
+                        [0, 14, 28],  # s4: 10MB/280MB autoBroadcastJoinThreshold
+                        [10, 20, 50],  # s5: 80/400 sql.shuffle.partitions
+                        [2],  # s6 default
+                        [50],  # s7: default
+                        [0, 2, 4],  # s8: spark.sql.files.maxPartitionBytes
+                        [0, 2, 4],  # s9: default <-- fixme: diff
+                    ]
+                else:
+                    raise Exception(
+                        f"# of theta_p samples {n_p_samples} "
+                        f"is not supported for {sample_mode}!"
+                    )
+            elif sample_mode == "grid-adaptive-cut-Cum5P-4":
+                # k3=[4, 10, 16] & turn on s3 in 81
+
+                # the choices of grid based on the selected importance of the knobs
+                # set default to parameters from the low rank to the high rank
+                # that cumulatively sum up to 5% of WMAPE
+                #
+                # k7, k1, k3, k2 (set k2, k4, k6, k5 and k8 to default)
+                # s4, s5, s8, s9, s1 (set s2, s3, s6, s7 to default)
+                if n_c_samples not in [54]:
+                    raise Exception(
+                        f"# of theta_c samples {n_c_samples} "
+                        f"is not supported for {sample_mode}!"
+                    )
+                if n_p_samples not in [81]:
+                    raise Exception(
+                        f"# of theta_p samples {n_p_samples} "
+                        f"is not supported for {sample_mode}!"
+                    )
+                if n_c_samples == 54:  # chosen <- 3-value strateg
+                    c_grids = [
+                        [1, 3, 5],  # k1
+                        [1, 2, 3],  # k2
+                        [4, 10, 16],  # k3 -> Fixme: diff
+                        [2],  # k4 - from best practice
+                        [2],  # k5 - default: 2
+                        [0],  # k6 - set to "0"
+                        [0, 1],  # k7 -> Fixme: diff
+                        [60],  # k8 - default: 60
+                    ]
+                else:
+                    raise Exception(
+                        f"# of theta_c samples {n_c_samples} "
+                        f"is not supported for {sample_mode}!"
+                    )
+
+                # s4, s5, s8, s9, s1 (set s2, s3, s6, s7 to default)
+                # for some realistic concerns, we reset the range for
+                # s4: [0MB - 280MB] to avoid failures and missing good broadcast
+                # s5: [10 - 50] to avoid bad performance within same resource usage
+                if n_p_samples == 81:  # 3^4 = 81
+                    p_grids = [
+                        [2],  # s1 <--
+                        [2],  # s2 default
+                        [
+                            0,
+                            14,
+                            28,
+                        ],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
+                        [0, 14, 28],  # s4: 10MB/280MB autoBroadcastJoinThreshold
+                        [10, 20, 50],  # s5: 80/400 sql.shuffle.partitions
+                        [2],  # s6 default
+                        [50],  # s7: default
+                        [0, 2, 4],  # s8: spark.sql.files.maxPartitionBytes
+                        [2],  # s9: default <-- fixme: diff
+                    ]
+                else:
+                    raise Exception(
+                        f"# of theta_p samples {n_p_samples} "
+                        f"is not supported for {sample_mode}!"
+                    )
+
+            elif sample_mode == "grid-adaptive-cut-Cum5P-5":
+                # k3=[8, 12, 16] & turn on s3 in 81
+
                 # the choices of grid based on the selected importance of the knobs
                 # set default to parameters from the low rank to the high rank
                 # that cumulatively sum up to 5% of WMAPE
@@ -1907,20 +2046,23 @@ class HierarchicalOptimizer(BaseOptimizer):
                     p_grids = [
                         [2],  # s1 <--
                         [2],  # s2 default
-                        [0],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
+                        [
+                            0,
+                            14,
+                            28,
+                        ],  # s3 default: 0MB maxShuffledHashJoinLocalMapThreshold
                         [0, 14, 28],  # s4: 10MB/280MB autoBroadcastJoinThreshold
                         [10, 20, 50],  # s5: 80/400 sql.shuffle.partitions
                         [2],  # s6 default
                         [50],  # s7: default
                         [0, 2, 4],  # s8: spark.sql.files.maxPartitionBytes
-                        [0, 2, 4],  # s9: default <-- fixme: diff
+                        [2],  # s9: default <-- fixme: diff
                     ]
                 else:
                     raise Exception(
                         f"# of theta_p samples {n_p_samples} "
                         f"is not supported for {sample_mode}!"
                     )
-
             else:
                 raise Exception(
                     f"The sample mode {sample_mode} for theta is not supported!"

--- a/udao_spark/optimizer/moo_algos/hierarchical_moo_with_constraints.py
+++ b/udao_spark/optimizer/moo_algos/hierarchical_moo_with_constraints.py
@@ -1467,7 +1467,7 @@ class Hierarchical_MOO_with_Constraints:
         :param theta_c_samples: theta_c samples
         :return: newly generated theta_c samples
         """
-        if theta_sample_mode == "grid-search":
+        if theta_sample_mode.startswith("grid"):
             (
                 new_theta_c_list,
                 tc_random_sample_new_theta_c,

--- a/udao_spark/optimizer/runtime_optimizer.py
+++ b/udao_spark/optimizer/runtime_optimizer.py
@@ -186,7 +186,7 @@ class RuntimeOptimizer:
             logger.info(f"> got non_decision_input and ro in {(t3 - t2) // 1e6} ms")
         monitor.input_extraction_ms = (t3 - t2) / 1e6  # monitoring
 
-        po_objs, po_confs = ro.solve(
+        po_objs, po_confs, _ = ro.solve(
             template=parsed_dict["TemplateId"],
             non_decision_input=non_decision_input,
             seed=self.seed,

--- a/udao_spark/utils/params.py
+++ b/udao_spark/utils/params.py
@@ -242,13 +242,7 @@ def get_compile_time_optimizer_parameters() -> ArgumentParser:
 
     parser.add_argument("--sample_mode", type=str, default="grid-search",
                         choices=["grid-search", "random", "lhs",
-                                 "grid-adaptive-cut-1P", "grid-adaptive-cut-5P",
-                                 "grid-adaptive-cut-Cum5P",
-                                 "grid-adaptive-cut-Cum5P-2",
-                                 "grid-adaptive-cut-Cum5P-3",
-                                 "grid-adaptive-cut-Cum5P-4",
-                                 "grid-adaptive-cut-Cum5P-5"
-                                 ],
+                                 "grid-adaptive-cut"],
                         help="Sample type for HMOOC")
     parser.add_argument("--pop_size", type=int, default=100,
                         help="Population size in EVO")

--- a/udao_spark/utils/params.py
+++ b/udao_spark/utils/params.py
@@ -245,7 +245,10 @@ def get_compile_time_optimizer_parameters() -> ArgumentParser:
                                  "grid-adaptive-cut-1P", "grid-adaptive-cut-5P",
                                  "grid-adaptive-cut-Cum5P",
                                  "grid-adaptive-cut-Cum5P-2",
-                                 "grid-adaptive-cut-Cum5P-3"],
+                                 "grid-adaptive-cut-Cum5P-3",
+                                 "grid-adaptive-cut-Cum5P-4",
+                                 "grid-adaptive-cut-Cum5P-5"
+                                 ],
                         help="Sample type for HMOOC")
     parser.add_argument("--pop_size", type=int, default=100,
                         help="Population size in EVO")

--- a/udao_spark/utils/params.py
+++ b/udao_spark/utils/params.py
@@ -243,8 +243,9 @@ def get_compile_time_optimizer_parameters() -> ArgumentParser:
     parser.add_argument("--sample_mode", type=str, default="grid-search",
                         choices=["grid-search", "random", "lhs",
                                  "grid-adaptive-cut-1P", "grid-adaptive-cut-5P",
-                                 "grid-adaptive-cut-Cum5P",  "grid-adaptive-cut-Cum5P-2"
-                                 ],
+                                 "grid-adaptive-cut-Cum5P",
+                                 "grid-adaptive-cut-Cum5P-2",
+                                 "grid-adaptive-cut-Cum5P-3"],
                         help="Sample type for HMOOC")
     parser.add_argument("--pop_size", type=int, default=100,
                         help="Population size in EVO")

--- a/udao_spark/utils/params.py
+++ b/udao_spark/utils/params.py
@@ -241,7 +241,8 @@ def get_compile_time_optimizer_parameters() -> ArgumentParser:
                         help="the number of random samples of theta_p")
 
     parser.add_argument("--sample_mode", type=str, default="grid-search",
-                        choices=["grid-search", "random", "lhs"],
+                        choices=["grid-search", "random", "lhs",
+                                 "grid-adaptive-cut-1P", "grid-adaptive-cut-5P"],
                         help="Sample type for HMOOC")
     parser.add_argument("--pop_size", type=int, default=100,
                         help="Population size in EVO")
@@ -270,8 +271,6 @@ def get_compile_time_optimizer_parameters() -> ArgumentParser:
                              "which is fine-grained control by default")
 
     # add by chenghao
-    parser.add_argument("--weights", nargs="+", type=float,
-                        default=[0.9, 0.1])
     parser.add_argument("--conf_save", type=str,
                         default="chenghao_conf_save")
     parser.add_argument("--selected_features", action="store_true")

--- a/udao_spark/utils/params.py
+++ b/udao_spark/utils/params.py
@@ -242,7 +242,9 @@ def get_compile_time_optimizer_parameters() -> ArgumentParser:
 
     parser.add_argument("--sample_mode", type=str, default="grid-search",
                         choices=["grid-search", "random", "lhs",
-                                 "grid-adaptive-cut-1P", "grid-adaptive-cut-5P"],
+                                 "grid-adaptive-cut-1P", "grid-adaptive-cut-5P",
+                                 "grid-adaptive-cut-Cum5P"
+                                 ],
                         help="Sample type for HMOOC")
     parser.add_argument("--pop_size", type=int, default=100,
                         help="Population size in EVO")

--- a/udao_spark/utils/params.py
+++ b/udao_spark/utils/params.py
@@ -243,7 +243,7 @@ def get_compile_time_optimizer_parameters() -> ArgumentParser:
     parser.add_argument("--sample_mode", type=str, default="grid-search",
                         choices=["grid-search", "random", "lhs",
                                  "grid-adaptive-cut-1P", "grid-adaptive-cut-5P",
-                                 "grid-adaptive-cut-Cum5P"
+                                 "grid-adaptive-cut-Cum5P",  "grid-adaptive-cut-Cum5P-2"
                                  ],
                         help="Sample type for HMOOC")
     parser.add_argument("--pop_size", type=int, default=100,

--- a/udao_trace_examples/scripts/run_spark_trace_on_demand.sh
+++ b/udao_trace_examples/scripts/run_spark_trace_on_demand.sh
@@ -1,0 +1,45 @@
+bm=$1
+cname=$2
+weights=$3
+nreps=$4
+runtime=$5
+
+if [ "$bm" = "tpch" ]; then
+  host=node21-opa
+  bt=TPCH
+  cn=HEX1
+elif [ "$bm" = "tpcds" ]; then
+  host=localhost
+  bt=TPCDS
+  cn=HEX2
+else
+  echo "Invalid benchmark specified"
+  exit 1
+fi
+
+if [ "$runtime" -eq 1 ]; then
+    python spark_trace_on_demand.py \
+    --trace_header "evaluations" \
+    --n_data_per_template 1 \
+    --benchmark_type $bt \
+    --cluster_name $cn \
+    --n_processes 1 \
+    --cluster_cores 120 \
+    --n_reps $nreps \
+    --enable_runtime_optimizer \
+    --runtime_optimizer_host $host \
+    --runtime_optimizer_port 12345 \
+    --configuration_header divB_new_grids/on_demand \
+    --configuration_name ${cname}_${weights}.json
+else
+    python spark_trace_on_demand.py \
+    --trace_header "evaluations" \
+    --n_data_per_template 1 \
+    --benchmark_type $bt \
+    --cluster_name $cn \
+    --n_processes 16 \
+    --cluster_cores 120 \
+    --n_reps $nreps \
+    --configuration_header divB_new_grids/on_demand \
+    --configuration_name ${cname}_${weights}.json
+fi

--- a/udao_trace_examples/scripts/run_spark_trace_on_demand.sh
+++ b/udao_trace_examples/scripts/run_spark_trace_on_demand.sh
@@ -1,7 +1,7 @@
 bm=$1
 cname=$2
-nreps=$4
-runtime=$5
+nreps=$3
+runtime=$4
 
 if [ "$bm" = "tpch" ]; then
   host=node21-opa

--- a/udao_trace_examples/scripts/run_spark_trace_on_demand.sh
+++ b/udao_trace_examples/scripts/run_spark_trace_on_demand.sh
@@ -29,7 +29,7 @@ if [ "$runtime" -eq 1 ]; then
     --runtime_optimizer_host $host \
     --runtime_optimizer_port 12345 \
     --configuration_header divB_new_grids/on_demand \
-    --configuration_name ${cname}
+    --configuration_name "${cname}"
 else
     python spark_trace_on_demand.py \
     --trace_header "evaluations" \
@@ -40,5 +40,5 @@ else
     --cluster_cores 120 \
     --n_reps $nreps \
     --configuration_header divB_new_grids/on_demand \
-    --configuration_name ${cname}
+    --configuration_name "${cname}"
 fi

--- a/udao_trace_examples/scripts/run_spark_trace_on_demand.sh
+++ b/udao_trace_examples/scripts/run_spark_trace_on_demand.sh
@@ -1,6 +1,5 @@
 bm=$1
 cname=$2
-weights=$3
 nreps=$4
 runtime=$5
 

--- a/udao_trace_examples/scripts/run_spark_trace_on_demand.sh
+++ b/udao_trace_examples/scripts/run_spark_trace_on_demand.sh
@@ -30,7 +30,7 @@ if [ "$runtime" -eq 1 ]; then
     --runtime_optimizer_host $host \
     --runtime_optimizer_port 12345 \
     --configuration_header divB_new_grids/on_demand \
-    --configuration_name ${cname}_${weights}.json
+    --configuration_name ${cname}
 else
     python spark_trace_on_demand.py \
     --trace_header "evaluations" \
@@ -41,5 +41,5 @@ else
     --cluster_cores 120 \
     --n_reps $nreps \
     --configuration_header divB_new_grids/on_demand \
-    --configuration_name ${cname}_${weights}.json
+    --configuration_name ${cname}
 fi


### PR DESCRIPTION
Add the new grid setting `grid-adaptive-cut` that constructs the grid by cutting over the parameters according to the rank list.

Here is the strategy of:
1. rank the parameters based on the aggregated permutation score of four separate models of (TPCH, TPCDS) X (lat, shuffle). 
2. parameter picking:
    - first pick the query plan related parameters: s3, s4
    - cutting the parameters from lowest to the highest when the cumulative importance is 5% of WMAPE -> drop `k4, k6, s11, s6, s7, s10, k5, k8, s2`
3. sampling rate in each parameter
    - for boolean parameter (k7), two choices 
    - for other continuous parameters, choose from [middle] -> [min, middle, max] -> [min, 1quatile, middle, 3qutile, max]
  
The global sampling rate we support for (theta_c, theta_p) is (54, 81), (90, 81), (150, 81). And we use (54, 81) by default. 

A running example for TPCH is the following. For the actual running, we always turned on the classifier. For predictive space, we can turn it off by add `--disable_failure_clf` 

```bash
nc=54
np=81
sample_mode=grid-adaptive-cut
python compile_time_hierarchical_optimizer.py \
    --q_type qs_lqp_compile \
    --ag_model_qs_ana_latency 'WeightedEnsemble_L2_FULL' \
    --ag_model_qs_io 'CatBoost' \
    --graph_choice gtn \
    --infer_limit 1e-5 \
    --infer_limit_batch_size 10000 \
    --ag_time_limit 21600 \
    --ag_sign 'high_quality' \
    --moo_algo 'hmooc%B' \
    --n_c_samples $nc \
    --n_p_samples $np \
    --sample_mode $sample_mode \
    --save_data \
    --save_data_header './output/' \
    --clf_recall_xhold -1
```

