### PR TITLE
ablation for op

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -7,6 +7,8 @@ disallow_untyped_calls = True
 [mypy-dgl.*]
 ignore_missing_imports = True
 
+[mypy-torch_geometric.*]
+ignore_missing_imports = True
 
 [mypy-gensim.*]
 ignore_missing_imports = True

--- a/playground/run_graph_gtn_basic_mlp.py
+++ b/playground/run_graph_gtn_basic_mlp.py
@@ -1,0 +1,251 @@
+import hashlib
+from argparse import ArgumentParser
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, cast
+
+import torch as th
+from udao.data import QueryPlanIterator
+from udao.data.utils.query_plan import random_flip_positional_encoding
+from udao.model import UdaoModel
+from udao.model.embedders.layers.multi_head_attention import AttentionLayerName
+from udao.model.utils.utils import set_deterministic_torch
+from udao.utils.interfaces import UdaoEmbedItemShape
+from udao.utils.logging import logger
+
+from udao_spark.data.utils import get_split_iterators
+from udao_spark.model.embedders.graph_transformer import GraphTransformer
+from udao_spark.model.regressors.basic_mlp import BasicMLP
+from udao_spark.model.utils import MyLearningParams, train_and_dump
+from udao_spark.utils.collaborators import PathWatcher, TypeAdvisor
+from udao_spark.utils.params import (
+    ExtractParams,
+    UdaoParams,
+    get_graph_transformer_params,
+)
+
+
+@dataclass
+class GraphTransformerBasicMLPParams(UdaoParams):
+    iterator_shape: UdaoEmbedItemShape
+    op_groups: List[str]
+    output_size: int = 32
+    pos_encoding_dim: int = 8
+    gtn_n_layers: int = 2
+    gtn_n_heads: int = 2
+    readout: str = "mean"
+    type_embedding_dim: int = 8
+    embedding_normalizer: Optional[str] = None
+    attention_layer_name: AttentionLayerName = "GTN"
+    # For QF (QueryFormer)
+    max_dist: Optional[int] = None
+    max_height: Optional[int] = None
+    # For RAAL
+    non_siblings_map: Optional[Dict[int, Dict[int, List[int]]]] = None
+    # MLP
+    n_layers: int = 2
+    hidden_dim: int = 32
+    dropout: float = 0.1
+    use_batchnorm: bool = True
+    activate: str = "relu"
+
+    @classmethod
+    def from_dict(cls, data_dict: Dict[str, Any]) -> "GraphTransformerBasicMLPParams":
+        if "iterator_shape" not in data_dict:
+            raise ValueError("iterator_shape not found in data_dict")
+        if not isinstance(data_dict["iterator_shape"], UdaoEmbedItemShape):
+            iterator_shape_dict = data_dict["iterator_shape"]
+            data_dict["iterator_shape"] = UdaoEmbedItemShape(
+                embedding_input_shape={
+                    k: v
+                    for k, v in iterator_shape_dict["embedding_input_shape"]
+                    if k in data_dict["op_groups"]
+                },
+                feature_names=iterator_shape_dict["feature_names"],
+                output_names=iterator_shape_dict["output_names"],
+            )
+        else:
+            data_dict["iterator_shape"].embedding_input_shape = {
+                k: v
+                for k, v in data_dict["iterator_shape"].embedding_input_shape.items()
+                if k in data_dict["op_groups"]
+            }
+        if "attention_layer_name" in data_dict:
+            if (
+                data_dict["attention_layer_name"] == "RAAL"
+                and "non_siblings_map" not in data_dict
+            ):
+                raise ValueError("non_siblings_map not found for RAAL")
+            if (
+                data_dict["attention_layer_name"] == "QF"
+                and "max_dist" not in data_dict
+            ):
+                raise ValueError("max_dist not found for QF")
+            if (
+                data_dict["attention_layer_name"] == "QF"
+                and "max_height" not in data_dict
+            ):
+                raise ValueError("max_height not found for QF")
+        return cls(**data_dict)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            k: v if not isinstance(v, UdaoEmbedItemShape) else v.__dict__
+            for k, v in self.__dict__.items()
+            if v is not None and k not in ["non_siblings_map"]
+        }
+
+    def hash(self) -> str:
+        attributes_tuple = str(
+            (
+                str(self.iterator_shape),
+                tuple(self.op_groups),
+                self.output_size,
+                self.pos_encoding_dim,
+                self.gtn_n_layers,
+                self.gtn_n_heads,
+                self.readout,
+                self.type_embedding_dim,
+                self.embedding_normalizer,
+                self.n_layers,
+                self.hidden_dim,
+                self.dropout,
+                self.use_batchnorm,
+                self.activate,
+            )
+        ).encode("utf-8")
+        sha256_hash = hashlib.sha256(attributes_tuple)
+        hex12 = sha256_hash.hexdigest()[:12]
+        return f"graph_{self.attention_layer_name.lower()}_basic_mlp" + hex12
+
+
+def get_graph_transformer_basic_mlp(
+    params: GraphTransformerBasicMLPParams,
+) -> UdaoModel:
+    model = UdaoModel.from_config(
+        embedder_cls=GraphTransformer,
+        regressor_cls=BasicMLP,
+        iterator_shape=params.iterator_shape,
+        embedder_params={
+            "output_size": params.output_size,  # 128
+            "pos_encoding_dim": params.pos_encoding_dim,  # 8
+            "n_layers": params.gtn_n_layers,  # 2
+            "n_heads": params.gtn_n_heads,  # 2
+            "hidden_dim": params.output_size,  # same as out_size
+            "readout": params.readout,  # "mean"
+            "op_groups": params.op_groups,  # ["type", "cbo", "op_enc"]
+            "type_embedding_dim": params.type_embedding_dim,  # 8
+            "embedding_normalizer": params.embedding_normalizer,  # None
+            "attention_layer_name": params.attention_layer_name,  # "GTN"
+            "max_dist": params.max_dist,  # None
+            "max_height": params.max_height,  # None
+            "non_siblings_map": params.non_siblings_map,  # None
+        },
+        regressor_params={
+            "n_layers": params.n_layers,  # 3
+            "hidden_dim": params.hidden_dim,  # 512
+            "dropout": params.dropout,  # 0.1
+            "use_batchnorm": params.use_batchnorm,  # True
+            "activation": params.activate,  # "relu"
+        },
+    )
+    return model
+
+
+def get_params() -> ArgumentParser:
+    parser = get_graph_transformer_params()
+    # fmt: off
+    parser.add_argument("--activate", type=str, default="relu",
+                        choices=["relu", "elu", "tanh"],
+                        help="Activation function.")
+    parser.add_argument("--use_batchnorm", action="store_true",
+                        help="Whether to use batch normalization.")
+    # fmt: on
+    return parser
+
+
+logger.setLevel("INFO")
+if __name__ == "__main__":
+    params = get_graph_transformer_params().parse_args()
+    set_deterministic_torch(params.seed)
+    if params.benchmark == "tpcds":
+        th.set_float32_matmul_precision("medium")  # type: ignore
+    print(params)
+    device = "gpu" if th.cuda.is_available() else "cpu"
+    tensor_dtypes = th.float32
+    th.set_default_dtype(tensor_dtypes)  # type: ignore
+
+    # Data definition
+    ta = TypeAdvisor(q_type=params.q_type)
+    extract_params = ExtractParams.from_dict(
+        {
+            "lpe_size": params.lpe_size,
+            "vec_size": params.vec_size,
+            "seed": params.seed,
+            "q_type": params.q_type,
+            "debug": params.debug,
+        }
+    )
+    pw = PathWatcher(
+        Path(__file__).parent,
+        params.benchmark,
+        params.debug,
+        extract_params,
+        params.fold,
+    )
+    split_iterators = get_split_iterators(pw=pw, ta=ta, tensor_dtypes=tensor_dtypes)
+    train_iterator = cast(QueryPlanIterator, split_iterators["train"])
+    split_iterators["train"].set_augmentations(
+        [train_iterator.make_graph_augmentation(random_flip_positional_encoding)]
+    )
+    # Model definition and training
+    model_params = GraphTransformerBasicMLPParams.from_dict(
+        {
+            "iterator_shape": split_iterators["train"].shape,
+            "op_groups": params.op_groups,
+            "output_size": params.output_size,
+            "pos_encoding_dim": params.pos_encoding_dim,
+            "gtn_n_layers": params.gtn_n_layers,
+            "gtn_n_heads": params.gtn_n_heads,
+            "readout": params.readout,
+            "type_embedding_dim": params.type_embedding_dim,
+            "embedding_normalizer": params.embedding_normalizer,
+            "n_layers": params.n_layers,
+            "hidden_dim": params.hidden_dim,
+            "dropout": params.dropout,
+            "use_batchnorm": params.use_batchnorm,
+            "activate": params.activate,
+        }
+    )
+
+    if params.loss_weights is not None:
+        if len(params.loss_weights) != len(ta.get_objectives()):
+            raise ValueError(
+                f"loss_weights must have the same length as objectives, "
+                f"got {len(params.loss_weights)} and {len(ta.get_objectives())}"
+            )
+
+    learning_params = MyLearningParams.from_dict(
+        {
+            "epochs": params.epochs,
+            "batch_size": params.batch_size,
+            "init_lr": params.init_lr,
+            "min_lr": params.min_lr,
+            "weight_decay": params.weight_decay,
+            "loss_weights": params.loss_weights,
+        }
+    )
+
+    model = get_graph_transformer_basic_mlp(model_params)
+
+    train_and_dump(
+        ta=ta,
+        pw=pw,
+        model=model,
+        split_iterators=split_iterators,
+        extract_params=extract_params,
+        model_params=model_params,
+        learning_params=learning_params,
+        params=params,
+        device=device,
+    )

--- a/playground/run_graph_gtn_basic_mlp.py
+++ b/playground/run_graph_gtn_basic_mlp.py
@@ -166,7 +166,7 @@ def get_params() -> ArgumentParser:
 
 logger.setLevel("INFO")
 if __name__ == "__main__":
-    params = get_graph_transformer_params().parse_args()
+    params = get_params().parse_args()
     set_deterministic_torch(params.seed)
     if params.benchmark == "tpcds":
         th.set_float32_matmul_precision("medium")  # type: ignore

--- a/playground/run_graph_gtn_sk_mlp.py
+++ b/playground/run_graph_gtn_sk_mlp.py
@@ -1,0 +1,249 @@
+import hashlib
+from argparse import ArgumentParser
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, cast
+
+import torch as th
+from udao.data import QueryPlanIterator
+from udao.data.utils.query_plan import random_flip_positional_encoding
+from udao.model import UdaoModel
+from udao.model.embedders.layers.multi_head_attention import AttentionLayerName
+from udao.model.utils.utils import set_deterministic_torch
+from udao.utils.interfaces import UdaoEmbedItemShape
+from udao.utils.logging import logger
+
+from udao_spark.data.utils import get_split_iterators
+from udao_spark.model.embedders.graph_transformer import GraphTransformer
+from udao_spark.model.regressors.sk_mlp import SkipConnectionMLP
+from udao_spark.model.utils import MyLearningParams, train_and_dump
+from udao_spark.utils.collaborators import PathWatcher, TypeAdvisor
+from udao_spark.utils.params import (
+    ExtractParams,
+    UdaoParams,
+    get_graph_transformer_params,
+)
+
+
+@dataclass
+class GraphTransformerSKMLPParams(UdaoParams):
+    iterator_shape: UdaoEmbedItemShape
+    op_groups: List[str]
+    output_size: int = 32
+    pos_encoding_dim: int = 8
+    gtn_n_layers: int = 2
+    gtn_n_heads: int = 2
+    readout: str = "mean"
+    type_embedding_dim: int = 8
+    embedding_normalizer: Optional[str] = None
+    attention_layer_name: AttentionLayerName = "GTN"
+    # For QF (QueryFormer)
+    max_dist: Optional[int] = None
+    max_height: Optional[int] = None
+    # For RAAL
+    non_siblings_map: Optional[Dict[int, Dict[int, List[int]]]] = None
+    # MLP
+    n_layers: int = 2
+    hidden_dim: int = 32
+    dropout: float = 0.1
+    use_batchnorm: bool = True
+    activate: str = "relu"
+
+    @classmethod
+    def from_dict(cls, data_dict: Dict[str, Any]) -> "GraphTransformerSKMLPParams":
+        if "iterator_shape" not in data_dict:
+            raise ValueError("iterator_shape not found in data_dict")
+        if not isinstance(data_dict["iterator_shape"], UdaoEmbedItemShape):
+            iterator_shape_dict = data_dict["iterator_shape"]
+            data_dict["iterator_shape"] = UdaoEmbedItemShape(
+                embedding_input_shape={
+                    k: v
+                    for k, v in iterator_shape_dict["embedding_input_shape"]
+                    if k in data_dict["op_groups"]
+                },
+                feature_names=iterator_shape_dict["feature_names"],
+                output_names=iterator_shape_dict["output_names"],
+            )
+        else:
+            data_dict["iterator_shape"].embedding_input_shape = {
+                k: v
+                for k, v in data_dict["iterator_shape"].embedding_input_shape.items()
+                if k in data_dict["op_groups"]
+            }
+        if "attention_layer_name" in data_dict:
+            if (
+                data_dict["attention_layer_name"] == "RAAL"
+                and "non_siblings_map" not in data_dict
+            ):
+                raise ValueError("non_siblings_map not found for RAAL")
+            if (
+                data_dict["attention_layer_name"] == "QF"
+                and "max_dist" not in data_dict
+            ):
+                raise ValueError("max_dist not found for QF")
+            if (
+                data_dict["attention_layer_name"] == "QF"
+                and "max_height" not in data_dict
+            ):
+                raise ValueError("max_height not found for QF")
+        return cls(**data_dict)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            k: v if not isinstance(v, UdaoEmbedItemShape) else v.__dict__
+            for k, v in self.__dict__.items()
+            if v is not None and k not in ["non_siblings_map"]
+        }
+
+    def hash(self) -> str:
+        attributes_tuple = str(
+            (
+                str(self.iterator_shape),
+                tuple(self.op_groups),
+                self.output_size,
+                self.pos_encoding_dim,
+                self.gtn_n_layers,
+                self.gtn_n_heads,
+                self.readout,
+                self.type_embedding_dim,
+                self.embedding_normalizer,
+                self.n_layers,
+                self.hidden_dim,
+                self.dropout,
+                self.use_batchnorm,
+                self.activate,
+            )
+        ).encode("utf-8")
+        sha256_hash = hashlib.sha256(attributes_tuple)
+        hex12 = sha256_hash.hexdigest()[:12]
+        return f"graph_{self.attention_layer_name.lower()}_sk_mlp" + hex12
+
+
+def get_graph_transformer_sk_mlp(params: GraphTransformerSKMLPParams) -> UdaoModel:
+    model = UdaoModel.from_config(
+        embedder_cls=GraphTransformer,
+        regressor_cls=SkipConnectionMLP,
+        iterator_shape=params.iterator_shape,
+        embedder_params={
+            "output_size": params.output_size,  # 128
+            "pos_encoding_dim": params.pos_encoding_dim,  # 8
+            "n_layers": params.gtn_n_layers,  # 2
+            "n_heads": params.gtn_n_heads,  # 2
+            "hidden_dim": params.output_size,  # same as out_size
+            "readout": params.readout,  # "mean"
+            "op_groups": params.op_groups,  # ["type", "cbo", "op_enc"]
+            "type_embedding_dim": params.type_embedding_dim,  # 8
+            "embedding_normalizer": params.embedding_normalizer,  # None
+            "attention_layer_name": params.attention_layer_name,  # "GTN"
+            "max_dist": params.max_dist,  # None
+            "max_height": params.max_height,  # None
+            "non_siblings_map": params.non_siblings_map,  # None
+        },
+        regressor_params={
+            "n_layers": params.n_layers,  # 3
+            "hidden_dim": params.hidden_dim,  # 512
+            "dropout": params.dropout,  # 0.1
+            "use_batchnorm": params.use_batchnorm,  # True
+            "activation": params.activate,  # "relu"
+        },
+    )
+    return model
+
+
+def get_params() -> ArgumentParser:
+    parser = get_graph_transformer_params()
+    # fmt: off
+    parser.add_argument("--activate", type=str, default="relu",
+                        choices=["relu", "elu", "tanh"],
+                        help="Activation function.")
+    parser.add_argument("--use_batchnorm", action="store_true",
+                        help="Whether to use batch normalization.")
+    # fmt: on
+    return parser
+
+
+logger.setLevel("INFO")
+if __name__ == "__main__":
+    params = get_params().parse_args()
+    set_deterministic_torch(params.seed)
+    if params.benchmark == "tpcds":
+        th.set_float32_matmul_precision("medium")  # type: ignore
+    print(params)
+    device = "gpu" if th.cuda.is_available() else "cpu"
+    tensor_dtypes = th.float32
+    th.set_default_dtype(tensor_dtypes)  # type: ignore
+
+    # Data definition
+    ta = TypeAdvisor(q_type=params.q_type)
+    extract_params = ExtractParams.from_dict(
+        {
+            "lpe_size": params.lpe_size,
+            "vec_size": params.vec_size,
+            "seed": params.seed,
+            "q_type": params.q_type,
+            "debug": params.debug,
+        }
+    )
+    pw = PathWatcher(
+        Path(__file__).parent,
+        params.benchmark,
+        params.debug,
+        extract_params,
+        params.fold,
+    )
+    split_iterators = get_split_iterators(pw=pw, ta=ta, tensor_dtypes=tensor_dtypes)
+    train_iterator = cast(QueryPlanIterator, split_iterators["train"])
+    split_iterators["train"].set_augmentations(
+        [train_iterator.make_graph_augmentation(random_flip_positional_encoding)]
+    )
+    # Model definition and training
+    model_params = GraphTransformerSKMLPParams.from_dict(
+        {
+            "iterator_shape": split_iterators["train"].shape,
+            "op_groups": params.op_groups,
+            "output_size": params.output_size,
+            "pos_encoding_dim": params.pos_encoding_dim,
+            "gtn_n_layers": params.gtn_n_layers,
+            "gtn_n_heads": params.gtn_n_heads,
+            "readout": params.readout,
+            "type_embedding_dim": params.type_embedding_dim,
+            "embedding_normalizer": params.embedding_normalizer,
+            "n_layers": params.n_layers,
+            "hidden_dim": params.hidden_dim,
+            "dropout": params.dropout,
+            "use_batchnorm": params.use_batchnorm,
+            "activate": params.activate,
+        }
+    )
+
+    if params.loss_weights is not None:
+        if len(params.loss_weights) != len(ta.get_objectives()):
+            raise ValueError(
+                f"loss_weights must have the same length as objectives, "
+                f"got {len(params.loss_weights)} and {len(ta.get_objectives())}"
+            )
+
+    learning_params = MyLearningParams.from_dict(
+        {
+            "epochs": params.epochs,
+            "batch_size": params.batch_size,
+            "init_lr": params.init_lr,
+            "min_lr": params.min_lr,
+            "weight_decay": params.weight_decay,
+            "loss_weights": params.loss_weights,
+        }
+    )
+
+    model = get_graph_transformer_sk_mlp(model_params)
+
+    train_and_dump(
+        ta=ta,
+        pw=pw,
+        model=model,
+        split_iterators=split_iterators,
+        extract_params=extract_params,
+        model_params=model_params,
+        learning_params=learning_params,
+        params=params,
+        device=device,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pytest-mock==3.12.0
 chardet==5.2.0
 sphinx==7.2.6
 sphinx-book-theme==1.1.0
+torch_geometric==2.5.3

--- a/udao_spark/model/embedders/transformer/graph_transformer.py
+++ b/udao_spark/model/embedders/transformer/graph_transformer.py
@@ -1,0 +1,58 @@
+"""This module contains base class for graph-based query embedders."""
+from typing import Callable, List, Optional, Union
+
+import dgl
+import torch as th
+import torch_geometric
+import torch_geometric.data
+
+# type aliases to simplify the signature of the GraphTransformer
+Graph = Union[dgl.DGLGraph, torch_geometric.data.Data]
+Readout = Callable[[Graph], th.Tensor]
+
+
+class GraphTransformer(th.nn.Module):
+    """Base class for graph-based query embedders."""
+
+    def __init__(
+        self,
+        preprocess_layers: Optional[List[th.nn.Module]],
+        layers: List[th.nn.Module],
+        final_readout: Readout,
+    ):
+        """Instantiate a Graph Transformer for query graph embedding.
+
+        Args:
+            preprocess_layers (Optional[List[th.nn.Module]]):
+                pre-processing operations to perform on the input data.
+            layers (List[th.nn.Module]):
+                list of modules to apply in sequential order
+            final_readout (Readout): operation that is applied after the
+                layers, and which produces the final graph representation.
+        """
+        self.preprocess_layers = preprocess_layers
+
+        # Register layers as Modules
+        self.layers = th.nn.ModuleList(layers)
+
+        self.final_readout = final_readout
+
+    def forward(self, input: Graph) -> th.Tensor:
+        """Compute the forward pass of the Graph Transformer.
+
+        Args:
+            inputs (Graph): graph of a query plan
+
+        Returns:
+            th.Tensor: tensor representation of the query graph.
+        """
+        # apply preprocessing layers
+        if self.preprocess_layers:
+            for pre_process_layer in self.preprocess_layers:
+                input = pre_process_layer(input)
+
+        # apply forward layers
+        for layer in self.layers:
+            input = layer(input)
+
+        return self.final_readout(input)

--- a/udao_spark/model/regressors/basic_mlp.py
+++ b/udao_spark/model/regressors/basic_mlp.py
@@ -57,5 +57,7 @@ class BasicMLP(BaseRegressor):
 
     def forward(self, embedding: th.Tensor, inst_feat: th.Tensor) -> th.Tensor:
         input = th.cat([embedding, inst_feat], dim=1)
-        output = self.layers(input)
+        output = input
+        for layer in self.layers:
+            output = layer(output)
         return output

--- a/udao_spark/model/regressors/basic_mlp.py
+++ b/udao_spark/model/regressors/basic_mlp.py
@@ -1,0 +1,61 @@
+from dataclasses import dataclass
+from typing import List
+
+import torch as th
+import torch.nn as nn
+from udao.model import BaseRegressor
+
+
+class BasicMLP(BaseRegressor):
+    """
+    Basic MLP regressor, mimicing AutoGluon's EmbedNet.
+    """
+
+    @dataclass
+    class Params(BaseRegressor.Params):
+        hidden_dim: int
+        """Size of the hidden layers outputs."""
+        n_layers: int
+        """Number of layers in the MLP"""
+        dropout: float
+        """Probability of dropout."""
+        use_batchnorm: bool = True
+        """Whether to use batch normalization."""
+        activation: str = "relu"
+        """Activation function."""
+
+    def _load_layers(self, net_params: Params) -> nn.ModuleList:
+        """Create the list of fully connected layers."""
+
+        act_fn: nn.Module
+        if net_params.activation == "relu":
+            act_fn = nn.ReLU()
+        elif net_params.activation == "tanh":
+            act_fn = nn.Tanh()
+        elif net_params.activation == "elu":
+            act_fn = nn.ELU()
+        else:
+            raise ValueError(f"Unknown activation function: {net_params.activation}")
+
+        layers: List[nn.Module] = []
+        if net_params.use_batchnorm:
+            layers.append(nn.BatchNorm1d(self.input_dim))
+        layers.append(nn.Linear(self.input_dim, net_params.hidden_dim))
+        layers.append(act_fn)
+        for _ in range(net_params.n_layers - 1):
+            if net_params.use_batchnorm:
+                layers.append(nn.BatchNorm1d(net_params.hidden_dim))
+            layers.append(nn.Linear(net_params.hidden_dim, net_params.hidden_dim))
+            layers.append(act_fn)
+        layers.append(nn.Linear(net_params.hidden_dim, self.output_dim))
+        return nn.ModuleList(layers)
+
+    def __init__(self, net_params: Params) -> None:
+        """_summary_"""
+        super().__init__(net_params)
+        self.layers = self._load_layers(net_params)
+
+    def forward(self, embedding: th.Tensor, inst_feat: th.Tensor) -> th.Tensor:
+        input = th.cat([embedding, inst_feat], dim=1)
+        output = self.layers(input)
+        return output

--- a/udao_spark/model/regressors/sk_mlp.py
+++ b/udao_spark/model/regressors/sk_mlp.py
@@ -1,0 +1,67 @@
+from dataclasses import dataclass
+from typing import List
+
+import torch as th
+import torch.nn as nn
+from udao.model import BaseRegressor
+
+
+class SkipConnectionMLP(BaseRegressor):
+    """
+    Basic MLP regressor, mimicing AutoGluon's EmbedNet.
+    """
+
+    @dataclass
+    class Params(BaseRegressor.Params):
+        hidden_dim: int
+        """Size of the hidden layers outputs."""
+        n_layers: int
+        """Number of layers in the MLP"""
+        dropout: float
+        """Probability of dropout."""
+        use_batchnorm: bool = True
+        """Whether to use batch normalization."""
+        activation: str = "relu"
+        """Activation function."""
+
+    def _load_layers(self, net_params: Params) -> nn.ModuleList:
+        """Create the list of fully connected layers."""
+
+        act_fn: nn.Module
+        if net_params.activation == "relu":
+            act_fn = nn.ReLU()
+        elif net_params.activation == "tanh":
+            act_fn = nn.Tanh()
+        elif net_params.activation == "elu":
+            act_fn = nn.ELU()
+        else:
+            raise ValueError(f"Unknown activation function: {net_params.activation}")
+
+        layers: List[nn.Module] = []
+        if net_params.use_batchnorm:
+            layers.append(nn.BatchNorm1d(self.input_dim))
+        layers.append(nn.Linear(self.input_dim, net_params.hidden_dim - self.input_dim))
+        layers.append(act_fn)
+        for _ in range(net_params.n_layers - 1):
+            if net_params.use_batchnorm:
+                layers.append(nn.BatchNorm1d(net_params.hidden_dim))
+            layers.append(
+                nn.Linear(net_params.hidden_dim, net_params.hidden_dim - self.input_dim)
+            )
+            layers.append(act_fn)
+        layers.append(nn.Linear(net_params.hidden_dim, self.output_dim))
+        return nn.ModuleList(layers)
+
+    def __init__(self, net_params: Params) -> None:
+        """_summary_"""
+        super().__init__(net_params)
+        self.layers = self._load_layers(net_params)
+
+    def forward(self, embedding: th.Tensor, inst_feat: th.Tensor) -> th.Tensor:
+        input = th.cat([embedding, inst_feat], dim=1)
+        output = input
+        for layer in self.layers[:-1]:
+            output = layer(output)
+            if isinstance(layer, nn.Linear):
+                output = th.cat([output, input], dim=1)
+        return self.layers[-1](output)

--- a/udao_spark/model/utils.py
+++ b/udao_spark/model/utils.py
@@ -198,10 +198,20 @@ class GraphTransformerMLPParams(UdaoParams):
         if not isinstance(data_dict["iterator_shape"], UdaoEmbedItemShape):
             iterator_shape_dict = data_dict["iterator_shape"]
             data_dict["iterator_shape"] = UdaoEmbedItemShape(
-                embedding_input_shape=iterator_shape_dict["embedding_input_shape"],
+                embedding_input_shape={
+                    k: v
+                    for k, v in iterator_shape_dict["embedding_input_shape"]
+                    if k in data_dict["op_groups"]
+                },
                 feature_names=iterator_shape_dict["feature_names"],
                 output_names=iterator_shape_dict["output_names"],
             )
+        else:
+            data_dict["iterator_shape"].embedding_input_shape = {
+                k: v
+                for k, v in data_dict["iterator_shape"].embedding_input_shape.items()
+                if k in data_dict["op_groups"]
+            }
         if "attention_layer_name" in data_dict:
             if (
                 data_dict["attention_layer_name"] == "RAAL"

--- a/udao_spark/model/utils.py
+++ b/udao_spark/model/utils.py
@@ -673,6 +673,7 @@ def get_tuned_trainer(
     scheduler = UdaoLRScheduler(setup_cosine_annealing_lr, warmup.UntunedLinearWarmup)
     trainer = pl.Trainer(
         accelerator=device,
+        max_steps=params.epochs * (len(split_iterators["train"]) // params.batch_size),
         max_epochs=params.epochs,
         logger=tb_logger,
         log_every_n_steps=min(len(split_iterators["train"]) // params.batch_size, 50),

--- a/udao_spark/model/utils.py
+++ b/udao_spark/model/utils.py
@@ -57,7 +57,7 @@ class UdaoModule(udao.model.UdaoModule):
         self.log(
             "learning_rate",
             self.trainer.optimizers[0].param_groups[0]["lr"],
-            n_step=True,
+            on_step=True,
             on_epoch=True,
             prog_bar=True,
             logger=True,

--- a/udao_spark/model/utils.py
+++ b/udao_spark/model/utils.py
@@ -673,7 +673,8 @@ def get_tuned_trainer(
     scheduler = UdaoLRScheduler(setup_cosine_annealing_lr, warmup.UntunedLinearWarmup)
     trainer = pl.Trainer(
         accelerator=device,
-        max_steps=params.epochs * (len(split_iterators["train"]) // params.batch_size),
+        max_steps=params.epochs
+        * int(np.ceil(len(split_iterators["train"]) / params.batch_size)),
         max_epochs=params.epochs,
         logger=tb_logger,
         log_every_n_steps=min(len(split_iterators["train"]) // params.batch_size, 50),


### PR DESCRIPTION
1. drop the th.exp(X) for the MLP output
2. add a skip connection MLP 
3. fix a bug in the LRscheduler 
4. some quick observations from hyperparameter tuning results for the new structures (with `dropout=0.1, lr=1e-3, osize=32`)
   - skip_connection did help than basic MLP
   - `eps=200` and `300` are averagely close, but 300 has a better chance of hitting better results
   - adding capacity `(nlayers, nhidden)` does not necessarily help a lot in the testing range. 
   - with dropout, turning off batchnorm is better for the performance
   - weight decay options does not affect the performance a lot. `wd = 1e-2` tends to hit better performance in the distribution.
    <details><summary>hyper parameter distributions</summary><img alt="image" src="https://github.com/user-attachments/assets/c37df49a-611d-4147-9e72-d7781bad8935"></details>

5. at the second round of hyperparameter tuning, I fixed `dropout=0.1, lr=1e-3, eps=300, use_bn=False, wd=1e-2`. Try `osize` in `[16, 32, 64, 128]`, and tried `(nlayers, nhidden)` in `[(4, 256), (4, 512), (5, 256), (5, 512)]`.
